### PR TITLE
fix(push): prompt push in interactive mode

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -452,9 +452,17 @@ cli
     }
 
     // 3. PUSH LOGIC
+    // Interactive mode: no workflow flags provided (only --provider, --model, --hint)
+    const isInteractiveMode =
+      !options.commit &&
+      !options.stageAll &&
+      !options.push &&
+      !options.dangerouslyAutoApprove;
+
     await handlePush({
       push: options.push,
       dangerouslyAutoApprove: options.dangerouslyAutoApprove,
+      isInteractiveMode,
     });
 
     outro(pc.green("Done!"));

--- a/apps/cli/src/lib/push.ts
+++ b/apps/cli/src/lib/push.ts
@@ -9,6 +9,7 @@ import { push, addRemoteAndPush } from "./git.ts";
 export interface PushOptions {
   push: boolean;
   dangerouslyAutoApprove: boolean;
+  isInteractiveMode: boolean;
 }
 
 /**
@@ -87,8 +88,10 @@ export async function safePush(isAutomated: boolean): Promise<void> {
  */
 export async function handlePush(options: PushOptions): Promise<void> {
   if (options.push) {
+    // --push flag provided: push automatically
     await safePush(options.dangerouslyAutoApprove);
-  } else if (!options.dangerouslyAutoApprove) {
+  } else if (options.isInteractiveMode) {
+    // Interactive mode (no workflow flags): prompt user
     const shouldPush = await confirm({
       message: "Do you want to git push?",
       initialValue: false,
@@ -98,4 +101,5 @@ export async function handlePush(options: PushOptions): Promise<void> {
       await safePush(false);
     }
   }
+  // Flag-only mode without --push: do nothing (no prompt, no push)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to ai-git! -->

### Description

<!-- Please describe your changes and why they are needed -->
- treat missing workflow flags as interactive so we can prompt first
- pass interactive flag through handlePush and prompt only in that mode
- skip push prompt when workflow flags are set without --push

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] Documentation update
