### PR TITLE
fix(release): resolve README symlinks before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,15 @@ jobs:
             sed -i "s/\"0.0.0\"/\"${VERSION}\"/g" "$pkg"
           done
 
+      - name: Resolve README symlinks
+        run: |
+          # npm doesn't follow symlinks pointing outside the package directory
+          for readme in packages/npm/*/README.md; do
+            if [ -L "$readme" ]; then
+              cp --remove-destination "$(readlink -f "$readme")" "$readme"
+            fi
+          done
+
       - name: Validate all packages (dry-run)
         run: |
           for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do


### PR DESCRIPTION
## Summary

- Fix `@ai-git/cli` README not appearing on npmjs.com after publish
- npm doesn't follow symlinks pointing outside the package directory, so the symlink `README.md → ../../../README.md` was silently excluded from the tarball

## Changes

- Added a `Resolve README symlinks` step in the release workflow that replaces symlinks with actual file content before `npm publish`

## Test Plan

- [ ] Trigger a release and verify `@ai-git/cli` tarball includes README.md
- [ ] Confirm README displays on npmjs.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced npm publishing workflow to properly resolve README symlinks before package validation, ensuring correct files are included in published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->