### PR TITLE
fix(cli): harden commit generation flow

### DIFF
--- a/apps/cli/src/lib/ai-response.test.ts
+++ b/apps/cli/src/lib/ai-response.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "bun:test";
+import { normalizeAICommitMessage } from "./ai-response.ts";
+
+describe("normalizeAICommitMessage", () => {
+  test("strips markdown fences around a commit message", () => {
+    const raw = "```text\nfeat: add login\n```";
+
+    expect(normalizeAICommitMessage(raw)).toBe("feat: add login");
+  });
+
+  test("keeps the explicit final block from channel-tagged output", () => {
+    const raw =
+      "<|channel|>analysis<|message|>need a shorter header<|end|>\n" +
+      "<|channel|>final<|message|>fix(cli): trim retry prompt context<|end|>";
+
+    expect(normalizeAICommitMessage(raw)).toBe("fix(cli): trim retry prompt context");
+  });
+
+  test("removes a leading explanatory preamble", () => {
+    const raw = "Here is your commit message:\n\nfeat: add login";
+
+    expect(normalizeAICommitMessage(raw)).toBe("feat: add login");
+  });
+
+  test("does not over-extract from arbitrary prose", () => {
+    const raw = "I think feat: add login would work, but please double-check the scope.";
+
+    expect(normalizeAICommitMessage(raw)).toBe(raw);
+  });
+});

--- a/apps/cli/src/lib/ai-response.ts
+++ b/apps/cli/src/lib/ai-response.ts
@@ -1,0 +1,66 @@
+const EXPLICIT_FINAL_BLOCK_PATTERNS = [
+  /<\|channel\|>final<\|message\|>([\s\S]*?)(?:(?:<\|end\|>)|$)/i,
+  /<final>([\s\S]*?)<\/final>/i,
+];
+
+const CONTROL_TOKEN_PATTERN = /<\|[^>]+?\|>/g;
+const LEADING_PREAMBLE_PATTERN =
+  /^(?:here(?:'s| is) (?:your |the )?commit message|(?:generated |suggested )?commit message|final answer|commit)\s*:?\s*(.*)$/i;
+
+function stripCodeFences(text: string): string {
+  return text
+    .replace(/^\s*```[\w-]*\s*$/gm, "")
+    .replace(/^\s*```\s*$/gm, "")
+    .trim();
+}
+
+function extractExplicitFinalBlock(text: string): string {
+  for (const pattern of EXPLICIT_FINAL_BLOCK_PATTERNS) {
+    const match = text.match(pattern);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  return text;
+}
+
+function stripLeadingPreamble(text: string): string {
+  const lines = text.split("\n");
+  const firstContentIndex = lines.findIndex((line) => line.trim().length > 0);
+
+  if (firstContentIndex === -1) {
+    return text.trim();
+  }
+
+  const firstLine = lines[firstContentIndex]!.trim();
+  const preambleMatch = firstLine.match(LEADING_PREAMBLE_PATTERN);
+
+  if (!preambleMatch) {
+    return text.trim();
+  }
+
+  const inlineContent = preambleMatch[1]?.trim() ?? "";
+  if (inlineContent) {
+    lines[firstContentIndex] = inlineContent;
+  } else {
+    lines.splice(firstContentIndex, 1);
+  }
+
+  return lines.join("\n").trim();
+}
+
+export function normalizeAICommitMessage(raw: string): string {
+  let text = raw.trim();
+
+  if (!text) {
+    return "";
+  }
+
+  text = extractExplicitFinalBlock(text);
+  text = text.replace(CONTROL_TOKEN_PATTERN, "");
+  text = stripCodeFences(text);
+  text = stripLeadingPreamble(text);
+
+  return text.trim();
+}

--- a/apps/cli/src/lib/generation.ts
+++ b/apps/cli/src/lib/generation.ts
@@ -17,6 +17,7 @@ import { displayCommitMessage } from "./display.ts";
 import { wrapText } from "./utils.ts";
 import { TEMP_MSG_FILE } from "./paths.ts";
 import { CLIError } from "./errors.ts";
+import { normalizeAICommitMessage } from "./ai-response.ts";
 
 // ==============================================================================
 // AI GENERATION ENGINE
@@ -285,11 +286,7 @@ export async function runGenerationLoop(ctx: GenerationContext): Promise<Generat
           throw new CLIError(errorMessage);
         }
 
-        // Cleanup message
-        const cleanMsg = rawMsg
-          .replace(/^```.*/gm, "") // Remove code blocks
-          .replace(/```$/gm, "")
-          .trim();
+        const cleanMsg = normalizeAICommitMessage(rawMsg);
 
         if (!cleanMsg) {
           console.error(pc.red("Error: AI returned empty message."));

--- a/apps/cli/src/lib/validation.test.ts
+++ b/apps/cli/src/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { validateCommitMessage, type ValidationResult } from "./validation.ts";
+import { buildRetryContext, validateCommitMessage } from "./validation.ts";
 
 describe("validateCommitMessage", () => {
   // Critical: header length
@@ -139,5 +139,33 @@ describe("validateCommitMessage", () => {
       "feat(api)!: remove v1 endpoints\n\n- remove all v1 routes\n\nBREAKING CHANGE: v1 API no longer available";
     const result = validateCommitMessage(msg);
     expect(result.errors.some((e) => e.rule === "breaking-change-consistency")).toBe(false);
+  });
+});
+
+describe("buildRetryContext", () => {
+  test("includes exact header budget details for length-only failures", () => {
+    const previousMsg = "feat(cli)!: require budget-aware migration output for config v2";
+    const result = validateCommitMessage(previousMsg);
+
+    const context = buildRetryContext(result.errors, previousMsg);
+
+    expect(context).toContain(
+      'Previous output:\n"feat(cli)!: require budget-aware migration output for config v2"',
+    );
+    expect(context).toContain("- Current header length: 63");
+    expect(context).toContain("- Over limit by: 13");
+    expect(context).toContain('- Fixed prefix: "feat(cli)!: " (12 chars)');
+    expect(context).toContain("- Remaining subject budget: 38 chars");
+    expect(context).toContain("- Rewrite only the subject so the full header fits.");
+  });
+
+  test("does not add prefix-preservation guidance for mixed critical failures", () => {
+    const previousMsg = "Here is your commit message:\n\nfeat(cli): add config doctor";
+    const result = validateCommitMessage(previousMsg);
+
+    const context = buildRetryContext(result.errors, previousMsg);
+
+    expect(context).not.toContain("Remaining subject budget");
+    expect(context).not.toContain("Keep the current type, scope, and ! marker");
   });
 });

--- a/apps/cli/src/lib/validation.ts
+++ b/apps/cli/src/lib/validation.ts
@@ -29,6 +29,18 @@ const VALID_TYPES = [
   "revert",
 ];
 
+function getHeaderParts(header: string): { prefix: string; subject: string } | null {
+  const match = header.match(/^(\w+(?:\([^)]*\))?!?: )(.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    prefix: match[1]!,
+    subject: match[2]!,
+  };
+}
+
 /**
  * Validate a commit message against Conventional Commits rules.
  * Returns validation result with errors categorized by severity.
@@ -131,11 +143,31 @@ export function validateCommitMessage(msg: string): ValidationResult {
  * Injected into the next AI generation attempt.
  */
 export function buildRetryContext(errors: ValidationError[], previousMsg: string): string {
+  const criticalErrors = errors.filter((e) => e.severity === "critical");
+  const header = previousMsg.split("\n")[0] ?? "";
+  const headerParts = getHeaderParts(header);
+  const hasOnlyHeaderLengthError =
+    criticalErrors.length === 1 && criticalErrors[0]?.rule === "header-length";
+
   let context = `# VALIDATION ERRORS IN PREVIOUS ATTEMPT\n`;
-  context += `Previous output:\n"${previousMsg.split("\n")[0]}"\n\n`;
+  context += `Previous output:\n"${header}"\n\n`;
+
+  if (hasOnlyHeaderLengthError && headerParts) {
+    const overBy = Math.max(header.length - 50, 0);
+    const subjectBudget = Math.max(50 - headerParts.prefix.length, 0);
+
+    context += `Header budget:\n`;
+    context += `- Current header length: ${header.length}\n`;
+    context += `- Over limit by: ${overBy}\n`;
+    context += `- Fixed prefix: "${headerParts.prefix}" (${headerParts.prefix.length} chars)\n`;
+    context += `- Remaining subject budget: ${subjectBudget} chars\n`;
+    context += `- Keep the current type, scope, and ! marker if they are semantically correct.\n`;
+    context += `- Rewrite only the subject so the full header fits.\n\n`;
+  }
+
   context += `Issues:\n`;
 
-  for (const err of errors.filter((e) => e.severity === "critical")) {
+  for (const err of criticalErrors) {
     context += `- ${err.message}. Fix: ${err.suggestion}\n`;
   }
 

--- a/apps/cli/src/machines/generation.machine.test.ts
+++ b/apps/cli/src/machines/generation.machine.test.ts
@@ -146,6 +146,45 @@ describe("generationMachine", () => {
     expect(snap.output!.aborted).toBe(true);
   });
 
+  test("normalizes noisy AI output before validation", async () => {
+    const machine = generationMachine.provide({
+      actors: {
+        // @ts-expect-error — XState v5 test mock type inference
+        getBranchNameActor: fromPromise(async () => "main"),
+        // @ts-expect-error — XState v5 test mock type inference
+        gatherContextActor: fromPromise(async () => ({
+          diff: "",
+          commits: "",
+          fileList: "",
+        })),
+        // @ts-expect-error — XState v5 test mock type inference
+        invokeAIActor: fromPromise(
+          async () =>
+            "<|channel|>analysis<|message|>thinking<|end|>\n" +
+            "<|channel|>final<|message|>feat: add login<|end|>",
+        ),
+        // @ts-expect-error — XState v5 test mock type inference
+        selectActor: fromPromise(async () => "commit"),
+        // @ts-expect-error — XState v5 test mock type inference
+        commitActor: fromPromise(async () => ({
+          hash: "abc1234",
+          branch: "main",
+          subject: "feat: add login",
+          filesChanged: 1,
+          insertions: 1,
+          deletions: 0,
+          files: [],
+          isRoot: false,
+        })),
+      },
+    });
+    const actor = createActor(machine, { input: mockInput() });
+    actor.start();
+    const snap = await waitFor(actor, (s) => s.status === "done");
+    expect(snap.output!.message).toBe("feat: add login");
+    expect(snap.output!.committed).toBe(true);
+  });
+
   // GN14: dry-run
   test("GN14: dry-run skips AI call and returns done", async () => {
     let aiCalled = false;
@@ -263,6 +302,59 @@ describe("generationMachine", () => {
     const snap = await waitFor(actor, (s) => s.status === "done", { timeout: 10000 });
     expect(genCount).toBe(2);
     expect(snap.output!.committed).toBe(true);
+  });
+
+  test("passes prompt customization into the machine system prompt", async () => {
+    let capturedSystemPrompt = "";
+
+    const machine = generationMachine.provide({
+      actors: {
+        // @ts-expect-error — XState v5 test mock type inference
+        getBranchNameActor: fromPromise(async () => "main"),
+        // @ts-expect-error — XState v5 test mock type inference
+        gatherContextActor: fromPromise(async () => ({ diff: "", commits: "", fileList: "" })),
+        // @ts-expect-error — XState v5 test mock type inference
+        invokeAIActor: fromPromise(
+          async ({
+            input,
+          }: {
+            input: {
+              system: string;
+            };
+          }) => {
+            capturedSystemPrompt = input.system;
+            return "feat: add login";
+          },
+        ),
+        // @ts-expect-error — XState v5 test mock type inference
+        selectActor: fromPromise(async () => "commit"),
+        // @ts-expect-error — XState v5 test mock type inference
+        commitActor: fromPromise(async () => ({
+          hash: "abc",
+          branch: "main",
+          subject: "feat: add login",
+          filesChanged: 1,
+          insertions: 1,
+          deletions: 0,
+          files: [],
+          isRoot: false,
+        })),
+      },
+    });
+
+    const actor = createActor(machine, {
+      input: mockInput({
+        promptCustomization: {
+          context: "Generate commits for the CLI package.",
+          style: "Prefer short direct subjects.",
+        },
+      }),
+    });
+    actor.start();
+    await waitFor(actor, (s) => s.status === "done");
+
+    expect(capturedSystemPrompt).toContain("About: Generate commits for the CLI package.");
+    expect(capturedSystemPrompt).toContain("Style: Prefer short direct subjects.");
   });
 
   // GN-ERR: gatherContext failure → aborted

--- a/apps/cli/src/machines/generation.machine.ts
+++ b/apps/cli/src/machines/generation.machine.ts
@@ -19,6 +19,7 @@ import { extractErrorMessage } from "../lib/errors.ts";
 import type { CommitResult } from "../lib/git.ts";
 import type { ProviderAdapter } from "../providers/types.ts";
 import type { PromptCustomization } from "../config.ts";
+import { normalizeAICommitMessage } from "../lib/ai-response.ts";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -74,18 +75,6 @@ export interface GenerationOutput {
   message: string;
   committed: boolean;
   aborted: boolean;
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────
-
-/**
- * Clean markdown code blocks and stray backticks from AI response.
- */
-function cleanAIResponse(raw: string): string {
-  return raw
-    .replace(/^```\w*$/gm, "") // Remove opening fence lines (```lang)
-    .replace(/^```$/gm, "") // Remove closing fence lines
-    .trim();
 }
 
 // ── Machine ──────────────────────────────────────────────────────────
@@ -146,7 +135,7 @@ export const generationMachine = setup({
     assignAIResponse: assign({
       currentMessage: ({ event }) => {
         const raw = (event as { output?: string }).output ?? "";
-        return cleanAIResponse(raw);
+        return normalizeAICommitMessage(raw);
       },
     }),
     assignValidationResult: assign({
@@ -211,6 +200,8 @@ export const generationMachine = setup({
     options: input.options,
     slowWarningThresholdMs: input.slowWarningThresholdMs,
     adapter: input.adapter,
+    promptCustomization: input.promptCustomization,
+    editor: input.editor,
     branchName: null,
     diff: "",
     commits: "",
@@ -321,7 +312,7 @@ export const generationMachine = setup({
 
               return {
                 model: context.model,
-                system: buildSystemPrompt(),
+                system: buildSystemPrompt(context.promptCustomization),
                 prompt: userPrompt,
                 modelName: context.modelName,
                 slowThresholdMs: context.slowWarningThresholdMs,

--- a/apps/cli/src/prompt.test.ts
+++ b/apps/cli/src/prompt.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { buildSystemPrompt } from "./prompt.ts";
+
+describe("buildSystemPrompt", () => {
+  test("includes header budgeting instructions and cli examples", () => {
+    const prompt = buildSystemPrompt();
+
+    expect(prompt).toContain("<header-budgeting>");
+    expect(prompt).toContain("Generate the header as a constrained formatting task:");
+    expect(prompt).toContain(
+      "Do not output a header you have not checked against the 50 character limit",
+    );
+    expect(prompt).toContain("fix(cli): trim retry prompt context");
+    expect(prompt).toContain("feat(cli)!: migrate flags to config");
+  });
+
+  test("preserves prompt customization alongside the default instructions", () => {
+    const prompt = buildSystemPrompt({
+      context: "AI Git generates commit messages for a CLI tool.",
+      style: "Prefer direct subjects and terse bodies.",
+    });
+
+    expect(prompt).toContain("<project-context>");
+    expect(prompt).toContain("About: AI Git generates commit messages for a CLI tool.");
+    expect(prompt).toContain("Style: Prefer direct subjects and terse bodies.");
+    expect(prompt).toContain("<header-budgeting>");
+  });
+});

--- a/apps/cli/src/prompt.ts
+++ b/apps/cli/src/prompt.ts
@@ -20,6 +20,7 @@ Output ONLY the raw commit message. No markdown, no code blocks, no preamble.
 - Imperative mood: "add" not "added", "fix" not "fixed"
 - Lowercase subject, no trailing period
 - No markdown formatting (\`\`\`, **, etc.)
+- Do not output a header you have not checked against the 50 character limit
 </constraints>
 
 <format>
@@ -64,6 +65,23 @@ When unsure: Ask "what is the PRIMARY reason for these changes?"
 - Abbreviate: authentication→auth, configuration→config, dependencies→deps
 </scope-rules>
 
+<header-budgeting>
+Generate the header as a constrained formatting task:
+1. Choose the correct type.
+2. Choose a scope only when it is semantically useful.
+3. Add ! only for a real breaking change.
+4. Build the exact prefix: <type>(<scope>)!: or <type>(<scope>): or <type>:
+5. Count remaining subject budget from the final prefix and the required space after the colon.
+6. Write the subject to fit the remaining budget.
+7. If the full header is over 50 chars, rewrite ONLY the subject shorter and check again.
+
+Compression rules for the subject:
+- Prefer action + object.
+- Drop qualifiers, secondary clauses, and implementation detail first.
+- Prefer short concrete words over abstract wording like "support", "handling", "workflow", or "integration" unless essential.
+- Keep semantically required scope; shorten the subject instead.
+</header-budgeting>
+
 <adaptive-body>
 - Trivial changes (rename, typo, single-line fix): header only, no body
 - Small changes (<30 lines): header only unless context is needed
@@ -105,6 +123,14 @@ feat(config)!: migrate to JSON config format
 - add automatic migration script
 
 BREAKING CHANGE: .myapprc files must migrate to config.json
+
+fix(cli): trim retry prompt context
+
+feat(cli): show config doctor output
+
+feat(cli)!: migrate flags to config
+
+BREAKING CHANGE: legacy CLI flags now require config values
 </examples>`;
 
 // ==============================================================================


### PR DESCRIPTION
### Description

Hardens CLI commit generation so we validate the intended commit message instead of trusting raw model output, and so first-pass headers budget for scope and breaking-change prefixes more explicitly.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Other

### Changes

- add a shared AI response normalization helper that strips code fences, obvious channel/control markers, and leading preambles while preserving explicit final blocks
- use the shared normalization path in both the main generation loop and the XState machine before validation
- pass `promptCustomization` through the machine path so both generation flows build the same system prompt
- strengthen the system prompt with explicit header-budget instructions and tighter `cli` / `cli!` examples
- enrich length-only retry context with exact header length, overage, fixed prefix, and remaining subject budget
- add unit coverage for noisy-output normalization, prompt budgeting content, retry-context details, and machine-path parity

### Testing

- `bun test apps/cli/src/lib/ai-response.test.ts apps/cli/src/lib/validation.test.ts apps/cli/src/prompt.test.ts apps/cli/src/machines/generation.machine.test.ts`
- `bun run --cwd apps/cli typecheck`
- `bunx oxlint apps/cli/src/lib/ai-response.ts apps/cli/src/lib/ai-response.test.ts apps/cli/src/lib/generation.ts apps/cli/src/lib/validation.ts apps/cli/src/lib/validation.test.ts apps/cli/src/machines/generation.machine.ts apps/cli/src/machines/generation.machine.test.ts apps/cli/src/prompt.ts apps/cli/src/prompt.test.ts`
- [ ] Tested on macOS version:
- [ ] Tested with different input types
- [ ] Tested in pipe chains

### Screenshots

N/A

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced AI prompt with improved header-budgeting instructions and additional CLI commit examples for better quality generations.

* **Improvements**
  * Improved handling of AI-generated commit messages with robust normalization of complex response formats.
  * Enhanced validation error messages with detailed header budget guidance, including current length, overflow amount, and remaining subject budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->