### PR TITLE
feat(npm): add Windows ARM64 platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build for macOS x64
         working-directory: apps/cli
         run: |
+          rm -f dist/ai-git
           bun run build --target bun-darwin-x64
           test -f dist/ai-git || { echo "ERROR: dist/ai-git not found after build"; exit 1; }
           cd dist
@@ -44,6 +45,7 @@ jobs:
       - name: Build for Linux x64
         working-directory: apps/cli
         run: |
+          rm -f dist/ai-git
           bun run build --target bun-linux-x64
           test -f dist/ai-git || { echo "ERROR: dist/ai-git not found after build"; exit 1; }
           cd dist
@@ -52,6 +54,7 @@ jobs:
       - name: Build for Linux ARM64
         working-directory: apps/cli
         run: |
+          rm -f dist/ai-git
           bun run build --target bun-linux-arm64
           test -f dist/ai-git || { echo "ERROR: dist/ai-git not found after build"; exit 1; }
           cd dist
@@ -60,6 +63,7 @@ jobs:
       - name: Build for Windows x64
         working-directory: apps/cli
         run: |
+          rm -f dist/ai-git.exe
           bun run build --target bun-windows-x64
           test -f dist/ai-git.exe || { echo "ERROR: dist/ai-git.exe not found after build"; exit 1; }
           cd dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Build for Windows ARM64
         working-directory: apps/cli
         run: |
+          rm -f dist/ai-git.exe
           bun run build --target bun-windows-arm64
           test -f dist/ai-git.exe || { echo "ERROR: dist/ai-git.exe not found after build"; exit 1; }
           cd dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,14 @@ jobs:
           cd dist
           zip ai-git-windows-x64.zip ai-git.exe
 
+      - name: Build for Windows ARM64
+        working-directory: apps/cli
+        run: |
+          bun run build --target bun-windows-arm64
+          test -f dist/ai-git.exe || { echo "ERROR: dist/ai-git.exe not found after build"; exit 1; }
+          cd dist
+          zip ai-git-windows-arm64.zip ai-git.exe
+
       - name: Generate checksums
         working-directory: apps/cli/dist
         run: shasum -a 256 *.tar.gz *.zip > checksums.txt
@@ -89,6 +97,7 @@ jobs:
             apps/cli/dist/ai-git-linux-x64.tar.gz
             apps/cli/dist/ai-git-linux-arm64.tar.gz
             apps/cli/dist/ai-git-windows-x64.zip
+            apps/cli/dist/ai-git-windows-arm64.zip
             apps/cli/dist/checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,7 +178,8 @@ jobs:
             -p "ai-git-darwin-x64.tar.gz" \
             -p "ai-git-linux-arm64.tar.gz" \
             -p "ai-git-linux-x64.tar.gz" \
-            -p "ai-git-windows-x64.zip"
+            -p "ai-git-windows-x64.zip" \
+            -p "ai-git-windows-arm64.zip"
 
       - name: Place binaries in platform packages
         run: |
@@ -188,6 +198,11 @@ jobs:
           unzip -o /tmp/artifacts/ai-git-windows-x64.zip -d packages/npm/win32-x64/bin
           test -f packages/npm/win32-x64/bin/ai-git.exe || { echo "ERROR: ai-git.exe not found after extraction"; exit 1; }
 
+          # Windows ARM64
+          mkdir -p packages/npm/win32-arm64/bin
+          unzip -o /tmp/artifacts/ai-git-windows-arm64.zip -d packages/npm/win32-arm64/bin
+          test -f packages/npm/win32-arm64/bin/ai-git.exe || { echo "ERROR: ai-git.exe not found after extraction"; exit 1; }
+
           # Update all 0.0.0 versions (package version + optionalDependencies)
           for pkg in packages/npm/*/package.json; do
             sed -i "s/\"0.0.0\"/\"${VERSION}\"/g" "$pkg"
@@ -204,7 +219,7 @@ jobs:
 
       - name: Validate all packages (dry-run)
         run: |
-          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
+          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
             echo "Validating @ai-git/${pkg}..."
             cd "packages/npm/${pkg}"
             npm publish --provenance --access public --dry-run
@@ -216,7 +231,7 @@ jobs:
 
       - name: Publish platform packages
         run: |
-          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
+          for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
             echo "Publishing @ai-git/${pkg}..."
             cd "packages/npm/${pkg}"
             npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "turbo": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "bun@1.3.9"
+  "packageManager": "bun@1.3.11"
 }

--- a/packages/npm/ai-git/bin/ai-git
+++ b/packages/npm/ai-git/bin/ai-git
@@ -8,7 +8,7 @@ const os = require("os");
 const PLATFORMS = {
   darwin: { arm64: "@ai-git/darwin-arm64", x64: "@ai-git/darwin-x64" },
   linux: { arm64: "@ai-git/linux-arm64", x64: "@ai-git/linux-x64" },
-  win32: { x64: "@ai-git/win32-x64" },
+  win32: { arm64: "@ai-git/win32-arm64", x64: "@ai-git/win32-x64" },
 };
 
 const platformPkgs = PLATFORMS[os.platform()];

--- a/packages/npm/ai-git/package.json
+++ b/packages/npm/ai-git/package.json
@@ -31,6 +31,7 @@
     "@ai-git/darwin-x64": "0.0.0",
     "@ai-git/linux-arm64": "0.0.0",
     "@ai-git/linux-x64": "0.0.0",
+    "@ai-git/win32-arm64": "0.0.0",
     "@ai-git/win32-x64": "0.0.0"
   }
 }

--- a/packages/npm/ai-git/scripts/postinstall.js
+++ b/packages/npm/ai-git/scripts/postinstall.js
@@ -5,7 +5,7 @@ const path = require("path");
 const PLATFORMS = {
   darwin: { arm64: "@ai-git/darwin-arm64", x64: "@ai-git/darwin-x64" },
   linux: { arm64: "@ai-git/linux-arm64", x64: "@ai-git/linux-x64" },
-  win32: { x64: "@ai-git/win32-x64" },
+  win32: { arm64: "@ai-git/win32-arm64", x64: "@ai-git/win32-x64" },
 };
 
 // Write install method marker

--- a/packages/npm/win32-arm64/README.md
+++ b/packages/npm/win32-arm64/README.md
@@ -1,0 +1,3 @@
+# @ai-git/win32-arm64
+
+This is the Windows ARM64 binary for [AI Git](https://github.com/sadiksaifi/ai-git), an AI-powered git commit message generator. See https://github.com/sadiksaifi/ai-git for details.

--- a/packages/npm/win32-arm64/package.json
+++ b/packages/npm/win32-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ai-git/win32-arm64",
+  "version": "0.0.0",
+  "description": "ai-git binary for Windows ARM64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sadiksaifi/ai-git"
+  },
+  "files": [
+    "bin/",
+    "README.md"
+  ],
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}


### PR DESCRIPTION
### Description

Add native Windows ARM64 binary distribution, enabled by Bun v1.3.11's `bun-windows-arm64` cross-compile target. Windows ARM64 devices (e.g. Snapdragon laptops) previously relied on x64 emulation — this ships a native binary for better performance.

### What is the purpose of this pull request?

- [x] New Feature

### Changes

- Add `@ai-git/win32-arm64` platform package (`packages/npm/win32-arm64/`)
- Register `arm64` arch in win32 PLATFORMS maps (`bin/ai-git`, `scripts/postinstall.js`)
- Add `@ai-git/win32-arm64` as optional dependency in `@ai-git/cli`
- CI: build with `--target bun-windows-arm64`, zip, release, download, extract, validate, and publish the new artifact

### Testing

- [x] `bun install` succeeds with new workspace package
- [x] `bun run typecheck` passes
- [x] CI will validate end-to-end on next tag push (build + publish)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## QA

- Verify the release workflow builds `ai-git-windows-arm64.zip` successfully on next tag push
- Verify `@ai-git/win32-arm64` appears on npmjs.org after publish
- On a Windows ARM64 device: `npm install -g @ai-git/cli` should pull the native arm64 binary, not the x64 one