### PR TITLE
fix(ci): bypass Alchemy CI state-store guard for web deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -51,6 +51,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}
           DOMAIN: ${{ secrets.DOMAIN }}
+          # Local state is fine here: every resource sets `adopt: true`, so
+          # CI re-adopts on each run rather than tracking drift via state.
+          # Revisit with CloudflareStateStore if we start renaming/removing
+          # resources and need drift-based cleanup.
+          ALCHEMY_CI_STATE_STORE_CHECK: "false"
 
       - name: Ensure www → apex redirect rule
         working-directory: apps/web


### PR DESCRIPTION
## Summary

- Alchemy 0.91.2 started rejecting the default local state store when `process.env.CI` is set, to prevent orphaned resources from drift that can't be detected without persistent state.
- Our `alchemy.run.ts` relies on `adopt: true` on every resource, so CI re-adopts on each run instead of using state for reconciliation — a local state store is fine here.
- Set `ALCHEMY_CI_STATE_STORE_CHECK=false` on the deploy step to opt out of the guard and unblock the workflow that failed on #108's first run.

## Follow-up

If we ever start renaming or removing resources, switch to `CloudflareStateStore` (needs `ALCHEMY_STATE_TOKEN` secret + a small edit to `alchemy.run.ts`).

## Test plan

- [ ] Deploy Web workflow runs green on merge
- [ ] `https://ai-git.xyz` still serves the site, no resources regressed