### PR TITLE
fix(ci): build Astro site externally with Node 24 before deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Astro 6 requires Node >=22.12; the runner default is older. Bun runs
+      # alchemy/CLI itself, but the Astro build shells out to Node.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
       - uses: oven-sh/setup-bun@v2
 
       - name: Cache Bun install
@@ -42,6 +48,10 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Build site
+        working-directory: apps/web
+        run: bun run build
 
       - name: Deploy via Alchemy
         working-directory: apps/web

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -34,9 +34,13 @@ const app = await alchemy(APP_NAME, {
 
 // --- Resources ---
 
+// `build` is intentionally omitted — Alchemy's Website resource spawns the
+// build command as a Node subprocess during deploy, which breaks on runners
+// where Node is < 22.12 (Astro's minimum). Instead, the caller (local user
+// or CI) runs `bun run build` beforehand and Alchemy just uploads `./dist`.
+// This matches Alchemy's own pr-preview workflow.
 export const site = await Website("site", {
   name: `ai-git-${APP_NAME}`,
-  build: "bun run build",
   assets: "./dist",
   spa: false,
   url: true,


### PR DESCRIPTION
## Summary

- Root cause of the failed deploy on #108: Alchemy's `Website` resource spawns its `build` command as a Node subprocess during `alchemy deploy`. On the runner, `astro build`'s Node shebang resolved to the default Node 20, which Astro 6 rejects (requires `>=22.12`).
- Switch to the **external-build** pattern — the same pattern Alchemy itself uses in their `pr-preview` workflow:
  - `apps/web/alchemy.run.ts`: drop `build: "bun run build"`. Alchemy's `Website` source treats an omitted `build` as "build has already happened" and simply uploads `./dist`.
  - `.github/workflows/deploy-web.yml`: add `actions/setup-node@v4` pinning Node 24, then run `bun run build` as an explicit CI step before the Alchemy deploy.

## Why not keep the internal build?

The Alchemy CI docs' **Bun variant** omits `setup-node` entirely — it's a doc gap (their npm/pnpm/yarn variants all install Node 24 explicitly). Any deploy where Alchemy shells out to a Node-based build (Astro, Next, etc.) needs Node on PATH. External-build sidesteps this and separates build failures from deploy failures in the CI UI — matches Alchemy's own workflow.

## Local impact

Local deploys now need a two-step: `bun run build && bun run deploy`. The repo-level contract matches CI.

## Test plan

- [ ] `Deploy Web` workflow runs green on merge
- [ ] `https://ai-git.xyz` continues serving the current site (resource adoption preserves state)
- [ ] Typecheck green (already verified locally — `astro check` passes, 0 errors)