### PR TITLE
fix(ci): drop per-deploy www-redirect assertion

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -67,9 +67,7 @@ jobs:
           # resources and need drift-based cleanup.
           ALCHEMY_CI_STATE_STORE_CHECK: "false"
 
-      - name: Ensure www → apex redirect rule
-        working-directory: apps/web
-        run: bun scripts/setup-www-redirect.ts
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          DOMAIN: ${{ secrets.DOMAIN }}
+      # The www -> apex redirect rule is a one-time manual setup via
+      # apps/web/scripts/setup-www-redirect.ts (needs a broader CF token
+      # than the minimal-scope one used here). It doesn't change per-deploy.
+      # If it ever goes missing, re-run the script locally.

--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -48,10 +48,11 @@ export const site = await Website("site", {
   ...workerDomainConfig(env),
 });
 
-// Note: www → apex redirect rule is set up via scripts/setup-www-redirect.ts.
-// Alchemy 0.91.2's RedirectRule generates invalid wirefilter ("and ssl") and
-// doesn't expose target_url.expression for path capture, so we run it as a
-// post-deploy step against CF's REST API directly.
+// Note: www → apex redirect rule is a one-time setup via
+// scripts/setup-www-redirect.ts (run locally with a CF token that has
+// Rulesets read/write). Alchemy 0.91.2's RedirectRule generates invalid
+// wirefilter ("and ssl") and doesn't expose target_url.expression for
+// path capture, so we configure it against CF's REST API directly.
 
 console.info(`Web -> ${displayUrl(env, site.url ?? "http://localhost:4321")}`);
 


### PR DESCRIPTION
## Summary

Deploy on #110 succeeded at the actual Alchemy step, but the post-deploy `Ensure www -> apex redirect rule` step failed. Cause: the minimal-scope CI token doesn't have Rulesets read/write. The script misread the 403 as "ruleset not found", tried to create the ruleset, and hit the auth error again.

Since the redirect rule doesn't change per deploy (one-time setup, currently working in prod — verified via `curl -I https://www.ai-git.xyz/foo`), the right fix is to drop this step from CI entirely. If the rule ever needs to be reconfigured, run `bun scripts/setup-www-redirect.ts` locally with a broader CF token.

## Verification

Live checks from `main` post-#110:

```
$ curl -sI https://ai-git.xyz/ | head -1
HTTP/2 200

$ curl -sI https://www.ai-git.xyz/foo/bar | head -3
HTTP/2 301
location: https://ai-git.xyz/foo/bar

$ curl -sI https://ai-git.xyz/install | head -3
HTTP/2 302
location: https://raw.githubusercontent.com/sadiksaifi/ai-git/main/install.sh
```

Site, www-redirect, install-redirect all green.

## Test plan

- [ ] Deploy Web workflow succeeds end-to-end after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment workflow configuration to reflect a one-time setup approach for domain redirect management.
  * Clarified internal documentation regarding domain configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->