### PR TITLE
fix(web): lift --color-muted to meet WCAG AA contrast

### DIFF
--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -4,7 +4,7 @@
   --color-bg: #0a0a0a;
   --color-fg: #ededed;
   --color-fg-dim: #a0a0a0;
-  --color-muted: #707070;
+  --color-muted: #8a8a8a;
   --color-border: #232323;
   --color-border-subtle: #1a1a1a;
 


### PR DESCRIPTION
## Summary

Lighthouse a11y flagged `--color-muted: #707070` against the dark bg at ~3.9:1 contrast — under WCAG AA's 4.5:1 for body text. Affected 14 elements across nav sublabels, CTA copy button label, terminal title, provider-grid badges, and footer links.

Bumping to `#8a8a8a` (~5.5:1 against the darkest background `#0a0a0a`). Still reads as muted.

## Lighthouse scores (pre-fix, against https://ai-git.xyz)

| Category | Score |
|---|---|
| Performance | 100 |
| Accessibility | 96 ← blocked by this contrast issue |
| Best Practices | 100 |
| SEO | 100 |

Core Web Vitals all green: FCP 0.8s, LCP 1.6s, TBT 0ms, CLS 0, SI 0.8s.

## Test plan

- [ ] Merge + deploy
- [ ] Re-run Lighthouse against https://ai-git.xyz — expect Accessibility 100