### PR TITLE
fix(web): unify vertical rhythm between marketing sections

### DIFF
--- a/apps/web/src/components/FAQ.astro
+++ b/apps/web/src/components/FAQ.astro
@@ -4,7 +4,9 @@ import { faq } from "@ai-git/content/web"
 
 <section class="faq" aria-labelledby="faq-heading">
   <div class="inner">
-    <h2 id="faq-heading">Questions.</h2>
+    <header class="section-head">
+      <h2 id="faq-heading">Questions.</h2>
+    </header>
     <dl>
       {
         faq.map((q) => (
@@ -20,15 +22,21 @@ import { faq } from "@ai-git/content/web"
 
 <style>
   .faq {
-    padding: var(--space-16) var(--container-pad);
+    padding: var(--section-y) var(--container-pad);
+    border-top: 1px solid var(--color-border);
   }
   .inner {
     max-width: var(--container-max);
     margin-inline: auto;
     display: grid;
-    gap: var(--space-6);
+    gap: var(--section-header-gap);
     justify-items: center;
     text-align: center;
+  }
+  .section-head {
+    display: grid;
+    gap: var(--section-title-gap);
+    justify-items: center;
   }
   h2 {
     font-size: var(--text-2xl);
@@ -37,7 +45,7 @@ import { faq } from "@ai-git/content/web"
     margin: 0;
     padding: 0;
     display: grid;
-    gap: var(--space-5);
+    gap: var(--space-6);
     max-width: 44rem;
     width: 100%;
     text-align: left;

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -14,9 +14,8 @@ import { footer } from "@ai-git/content/web"
 
 <style>
   .footer {
-    padding: var(--space-8) var(--container-pad);
-    border-top: 1px solid var(--color-border-subtle);
-    margin-top: var(--space-8);
+    padding: var(--space-12) var(--container-pad);
+    border-top: 1px solid var(--color-border);
   }
   .inner {
     max-width: var(--container-max);

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -15,13 +15,13 @@ import InstallCommand from "./InstallCommand.astro"
 
 <style>
   .hero {
-    padding: var(--space-24) var(--container-pad) var(--space-16);
+    padding: clamp(4rem, 7vw, 6rem) var(--container-pad) clamp(2.5rem, 5vw, 3.5rem);
   }
   .inner {
     max-width: var(--container-max);
     margin-inline: auto;
     display: grid;
-    gap: var(--space-6);
+    gap: var(--space-5);
     justify-items: center;
     text-align: center;
   }
@@ -38,7 +38,7 @@ import InstallCommand from "./InstallCommand.astro"
     text-wrap: balance;
   }
   .cta {
-    margin-top: var(--space-4);
+    margin-top: var(--space-3);
     max-width: 100%;
   }
 </style>

--- a/apps/web/src/components/Nav.astro
+++ b/apps/web/src/components/Nav.astro
@@ -39,7 +39,7 @@ const iconPath: Record<string, string> = {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: var(--space-4) var(--container-pad);
+    padding: var(--space-5) var(--container-pad);
     max-width: var(--container-max);
     margin-inline: auto;
   }

--- a/apps/web/src/components/ProviderGrid.astro
+++ b/apps/web/src/components/ProviderGrid.astro
@@ -6,8 +6,10 @@ const providers = Object.values(PROVIDERS).sort((a, b) => a.name.localeCompare(b
 
 <section class="providers" aria-labelledby="providers-heading">
   <div class="inner">
-    <h2 id="providers-heading">Works with your AI.</h2>
-    <p class="lede">Eight providers. No vendor lock-in.</p>
+    <header class="section-head">
+      <h2 id="providers-heading">Works with your AI.</h2>
+      <p class="lede">Eight providers. No vendor lock-in.</p>
+    </header>
     <ul class="grid">
       {
         providers.map((p) => (
@@ -28,17 +30,24 @@ const providers = Object.values(PROVIDERS).sort((a, b) => a.name.localeCompare(b
   </div>
 </section>
 
+
 <style>
   .providers {
-    padding: var(--space-16) var(--container-pad);
+    padding: var(--section-y) var(--container-pad);
+    border-top: 1px solid var(--color-border);
   }
   .inner {
     max-width: var(--container-max);
     margin-inline: auto;
     display: grid;
-    gap: var(--space-2);
+    gap: var(--section-header-gap);
     justify-items: center;
     text-align: center;
+  }
+  .section-head {
+    display: grid;
+    gap: var(--section-title-gap);
+    justify-items: center;
   }
   h2 {
     font-size: var(--text-2xl);
@@ -46,7 +55,6 @@ const providers = Object.values(PROVIDERS).sort((a, b) => a.name.localeCompare(b
   .lede {
     color: var(--color-fg-dim);
     font-size: var(--text-base);
-    margin-bottom: var(--space-6);
   }
   .grid {
     list-style: none;

--- a/apps/web/src/components/TerminalDemo.astro
+++ b/apps/web/src/components/TerminalDemo.astro
@@ -42,7 +42,7 @@ const body = lines
 
 <style>
   .demo-section {
-    padding: 0 var(--container-pad) var(--space-24);
+    padding: 0 var(--container-pad) var(--section-y);
   }
   .terminal {
     max-width: calc(var(--container-max) - 4rem);

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -37,6 +37,10 @@
   --container-max: 68rem;
   --container-pad: clamp(1rem, 3vw, 2rem);
 
+  --section-y: clamp(4rem, 7vw, 6rem);
+  --section-header-gap: clamp(2rem, 3.5vw, 2.75rem);
+  --section-title-gap: var(--space-3);
+
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;


### PR DESCRIPTION
## Summary

The marketing site's section gaps were inconsistent (96 / 56 / 240 / 128 / 128 px) and inner spacing relied on ad-hoc `--space-*` picks plus a `gap + margin-bottom` hack. This made the layout feel random rather than designed. Introduce a small rhythm system and apply it uniformly.

## Changes

- **Tokens (`global.css`)**: add `--section-y`, `--section-header-gap`, `--section-title-gap` so every section uses the same scale.
- **Hero + TerminalDemo paired**: Hero pads `~6rem / ~3rem`, Demo pads `0 / section-y`. Demo reads as the hero's payoff, then equal section-y to the next block.
- **Provider grid + FAQ**: uniform `section-y` top/bot; headings wrapped in `<header class="section-head">` with `--section-title-gap` between title and lede, then `--section-header-gap` down to body. Removed the `gap-2 + margin-bottom` workaround.
- **Dividers**: hairline `border-top` between Providers / FAQ / Footer, switched from `--color-border-subtle` (#1a1a1a, invisible on #0a0a0a bg) to `--color-border` (#232323, visible but quiet). None between Hero and Demo since they're a unit.
- **Footer**: dropped doubled `margin-top: --space-8 + padding: --space-8` for a single `padding: --space-12`.
- **Nav**: vertical padding 16→20px so it stops crowding the page edge.

Result: every section gap is now ~192px (96+96), each content section has a hairline divider above it, and internal title→body rhythm is consistent across Providers and FAQ.

## QA

- [ ] Open `/` on desktop (≥1280px wide) — vertical rhythm between Hero, Demo, Providers, FAQ, Footer should feel even, not random
- [ ] Verify Hero and TerminalDemo read as a paired block (small gap between them, larger gap to Providers below)
- [ ] Confirm hairline dividers are visible above Providers, FAQ, and Footer (subtle, not heavy)
- [ ] Resize down to ~768px and ~375px — section padding should scale via clamp without becoming cramped
- [ ] Tab through nav and provider links — focus rings still visible against the dark bg
- [ ] Toggle prefers-reduced-motion — terminal demo lines render immediately, no animation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and padding across multiple site sections for improved visual consistency
  * Enhanced responsive layout adjustments throughout the interface
  * Updated visual hierarchy of section headers and border styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->