### PR TITLE
Reduce Codex commit generation startup overhead

### DIFF
--- a/apps/cli/src/providers/cli/codex.test.ts
+++ b/apps/cli/src/providers/cli/codex.test.ts
@@ -76,6 +76,48 @@ describe("codexAdapter.invoke", () => {
     expect(idx).toBeGreaterThan(0);
     expect(cmd[idx - 1]).toBe("-c");
   });
+
+  it("should run Codex in a stripped-down headless mode", async () => {
+    const { codexAdapter } = await import("./codex.ts");
+    await codexAdapter.invoke({
+      model: "gpt-5.4-medium",
+      system: "test system",
+      prompt: "test prompt",
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const cmd = spawnCalls[0]!.cmd;
+
+    for (const feature of [
+      "shell_tool",
+      "shell_snapshot",
+      "apps",
+      "codex_hooks",
+      "multi_agent",
+      "personality",
+      "plugins",
+    ]) {
+      const idx = cmd.indexOf(feature);
+      expect(idx).toBeGreaterThan(0);
+      expect(cmd[idx - 1]).toBe("--disable");
+    }
+
+    for (const config of ['history.persistence="none"', "mcp_servers={}"]) {
+      const idx = cmd.indexOf(config);
+      expect(idx).toBeGreaterThan(0);
+      expect(cmd[idx - 1]).toBe("-c");
+    }
+
+    const execIdx = cmd.indexOf("exec");
+    expect(execIdx).toBeGreaterThan(0);
+    expect(cmd.slice(execIdx)).toEqual([
+      "exec",
+      "--sandbox",
+      "read-only",
+      "--ephemeral",
+      "test prompt",
+    ]);
+  });
 });
 
 describe("codex registry", () => {

--- a/apps/cli/src/providers/cli/codex.ts
+++ b/apps/cli/src/providers/cli/codex.ts
@@ -32,8 +32,10 @@ function parseModelId(virtualId: string): {
  *
  * Top-level options (before exec):
  * - `-a never` prevents interactive approval prompts
- * - `--disable shell_tool` removes shell tool from model's available tools
+ * - `--disable ...` removes optional tools and ambient runtime features
  * - `-c web_search="disabled"` disables web search
+ * - `-c history.persistence="none"` disables history persistence
+ * - `-c mcp_servers={}` disables configured MCP servers
  *
  * Exec subcommand options:
  * - `--sandbox read-only` enforces OS-level read-only filesystem
@@ -57,10 +59,24 @@ export const codexAdapter: CLIProviderAdapter = {
         "shell_tool",
         "--disable",
         "shell_snapshot",
+        "--disable",
+        "apps",
+        "--disable",
+        "codex_hooks",
+        "--disable",
+        "multi_agent",
+        "--disable",
+        "personality",
+        "--disable",
+        "plugins",
         "-c",
         "check_for_update_on_startup=false",
         "-c",
         "analytics.enabled=false",
+        "-c",
+        'history.persistence="none"',
+        "-c",
+        "mcp_servers={}",
         "-c",
         `model_reasoning_effort=${effort}`,
         "-c",


### PR DESCRIPTION
## Summary

- Trim ai-git's Codex CLI adapter for headless commit generation by disabling more ambient runtime features per invocation.
- Remove extra startup work from plugins, hooks, apps, multi-agent flows, persisted history, and configured MCP servers.
- Keep existing adapter contract and commit-generation prompt path unchanged.

## Changes

- Extend the Codex adapter disable set with `apps`, `codex_hooks`, `multi_agent`, `personality`, and `plugins`.
- Add per-invocation config overrides for `history.persistence="none"` and `mcp_servers={}` alongside the existing update-check, analytics, and web-search disables.
- Add adapter coverage that asserts the stripped-down command shape and preserves the `exec --sandbox read-only --ephemeral` tail.

## Test Plan

- `bun test apps/cli/src/providers/cli/codex.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run check`

## QA

- Codex provider flow: generate a commit message with `--provider codex` and confirm behavior is unchanged while the adapter still runs in non-interactive read-only mode.
- Startup-sensitive path: compare a few Codex-backed commit generations before and after this branch and confirm the branch avoids the extra ambient Codex runtime work.
- Regression surface: verify non-Codex providers still behave identically since only the Codex adapter command shape changed.

## Closes

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Codex CLI execution to enforce a restricted headless mode with hardened configuration settings.
  * Added test coverage validating the headless execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->