### PR TITLE
Rank dynamic CLI models during configure

### DIFF
--- a/apps/cli/src/lib/onboarding/dynamic-cli-models.test.ts
+++ b/apps/cli/src/lib/onboarding/dynamic-cli-models.test.ts
@@ -6,6 +6,9 @@ describe("loadDynamicCLIModelsForSetup", () => {
 
     const models = await loadDynamicCLIModelsForSetup("test-provider", {
       providerName: "Test Provider",
+      loadCatalog: async () => {
+        throw new Error("skip catalog in unit test");
+      },
       adapter: {
         providerId: "test-provider",
         mode: "cli",

--- a/apps/cli/src/lib/onboarding/dynamic-cli-models.test.ts
+++ b/apps/cli/src/lib/onboarding/dynamic-cli-models.test.ts
@@ -22,6 +22,39 @@ describe("loadDynamicCLIModelsForSetup", () => {
     expect(models).toEqual([{ id: "vendor/model#low", name: "Vendor Model (low)" }]);
   });
 
+  it("falls back when catalog loading does not settle", async () => {
+    const { loadDynamicCLIModelsForSetup } = await import("./dynamic-cli-models.ts");
+
+    const modelsPromise = loadDynamicCLIModelsForSetup("test-provider", {
+      providerName: "Test Provider",
+      catalogTimeoutMs: 1,
+      loadCatalog: async () => new Promise(() => {}),
+      adapter: {
+        providerId: "test-provider",
+        mode: "cli",
+        binary: "test",
+        checkAvailable: async () => true,
+        invoke: async () => "",
+        fetchModels: async () => [
+          { id: "openai-codex/gpt-5.4-mini#high", name: "GPT-5.4 Mini (high)" },
+          { id: "openai-codex/gpt-5.5-mini#minimal", name: "GPT-5.5 Mini (minimal)" },
+        ],
+      },
+    });
+
+    const models = await Promise.race([
+      modelsPromise,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("timed out waiting for catalog fallback")), 50);
+      }),
+    ]);
+
+    expect(models.map((model) => model.id)).toEqual([
+      "openai-codex/gpt-5.5-mini#minimal",
+      "openai-codex/gpt-5.4-mini#high",
+    ]);
+  });
+
   it("fails when a dynamic CLI adapter returns no usable models", async () => {
     const { loadDynamicCLIModelsForSetup } = await import("./dynamic-cli-models.ts");
 

--- a/apps/cli/src/lib/onboarding/dynamic-cli-models.ts
+++ b/apps/cli/src/lib/onboarding/dynamic-cli-models.ts
@@ -8,7 +8,32 @@ import { rankDynamicCLIModels } from "./dynamic-cli-ranking.ts";
 interface LoadDynamicCLIModelsOptions {
   providerName: string;
   adapter?: CLIProviderAdapter;
-  loadCatalog?: () => Promise<ModelCatalog>;
+  loadCatalog?: (options?: { signal?: AbortSignal }) => Promise<ModelCatalog>;
+  catalogTimeoutMs?: number;
+}
+
+const DYNAMIC_CLI_CATALOG_TIMEOUT_MS = 1500;
+
+async function loadOptionalCatalog(
+  loadCatalog: (options?: { signal?: AbortSignal }) => Promise<ModelCatalog>,
+  timeoutMs: number,
+): Promise<ModelCatalog | null> {
+  const controller = new AbortController();
+  let timeout: Timer | undefined;
+
+  const catalogPromise = loadCatalog({ signal: controller.signal }).catch(() => null);
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      resolve(null);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([catalogPromise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export async function loadDynamicCLIModelsForSetup(
@@ -35,10 +60,9 @@ export async function loadDynamicCLIModelsForSetup(
     provider: model.provider,
   }));
 
-  try {
-    const catalog = await (options.loadCatalog ?? getModelCatalog)();
-    return rankDynamicCLIModels(rows, catalog);
-  } catch {
-    return rankDynamicCLIModels(rows, null);
-  }
+  const catalog = await loadOptionalCatalog(
+    options.loadCatalog ?? getModelCatalog,
+    options.catalogTimeoutMs ?? DYNAMIC_CLI_CATALOG_TIMEOUT_MS,
+  );
+  return rankDynamicCLIModels(rows, catalog);
 }

--- a/apps/cli/src/lib/onboarding/dynamic-cli-models.ts
+++ b/apps/cli/src/lib/onboarding/dynamic-cli-models.ts
@@ -1,10 +1,14 @@
 import type { CLIProviderAdapter } from "../../providers/types.ts";
 import { getAdapter } from "../../providers/index.ts";
+import { getModelCatalog } from "../../providers/api/models/index.ts";
+import type { ModelCatalog } from "../../providers/api/models/types.ts";
 import type { CachedModel } from "../model-cache.ts";
+import { rankDynamicCLIModels } from "./dynamic-cli-ranking.ts";
 
 interface LoadDynamicCLIModelsOptions {
   providerName: string;
   adapter?: CLIProviderAdapter;
+  loadCatalog?: () => Promise<ModelCatalog>;
 }
 
 export async function loadDynamicCLIModelsForSetup(
@@ -25,9 +29,16 @@ export async function loadDynamicCLIModelsForSetup(
     );
   }
 
-  return models.map((model) => ({
+  const rows = models.map((model) => ({
     id: model.id,
     name: model.name,
     provider: model.provider,
   }));
+
+  try {
+    const catalog = await (options.loadCatalog ?? getModelCatalog)();
+    return rankDynamicCLIModels(rows, catalog);
+  } catch {
+    return rankDynamicCLIModels(rows, null);
+  }
 }

--- a/apps/cli/src/lib/onboarding/dynamic-cli-ranking.test.ts
+++ b/apps/cli/src/lib/onboarding/dynamic-cli-ranking.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { createCatalogFromRaw } from "../../providers/api/models/models-dev-client.ts";
+import type { CachedModel } from "../model-cache.ts";
+
+function dynamicCatalog() {
+  return createCatalogFromRaw(
+    {
+      anthropic: {
+        models: {
+          "claude-haiku-4-5": {
+            name: "Claude Haiku 4.5",
+            family: "claude-haiku",
+            release_date: "2025-10-16",
+            last_updated: "2025-10-16",
+            reasoning: true,
+            tool_call: true,
+          },
+        },
+      },
+      openai: {
+        models: {
+          "gpt-5.4": {
+            name: "GPT-5.4",
+            family: "gpt",
+            release_date: "2026-03-05",
+            last_updated: "2026-03-05",
+            reasoning: true,
+            tool_call: true,
+          },
+          "gpt-5.4-mini": {
+            name: "GPT-5.4 Mini",
+            family: "gpt-mini",
+            release_date: "2026-03-19",
+            last_updated: "2026-03-19",
+            reasoning: true,
+            tool_call: true,
+          },
+        },
+      },
+      google: {
+        models: {
+          "gemini-3-flash-preview": {
+            name: "Gemini 3 Flash Preview",
+            family: "gemini-flash",
+            release_date: "2025-12-18",
+            last_updated: "2025-12-18",
+            reasoning: false,
+            tool_call: true,
+          },
+        },
+      },
+    },
+    "snapshot",
+  );
+}
+
+describe("rankDynamicCLIModels", () => {
+  it("uses provider priority before catalog-enriched model freshness", async () => {
+    const { rankDynamicCLIModels } = await import("./dynamic-cli-ranking.ts");
+    const models: CachedModel[] = [
+      { id: "opencode/big-pickle", name: "Big Pickle" },
+      { id: "anthropic/claude-haiku-4-5#minimal", name: "Claude Haiku 4.5 (minimal)" },
+      { id: "openai/gpt-5.4-mini#minimal", name: "GPT-5.4 Mini (minimal)" },
+      { id: "google/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
+    ];
+
+    expect(rankDynamicCLIModels(models, dynamicCatalog()).map((model) => model.id)).toEqual([
+      "openai/gpt-5.4-mini#minimal",
+      "anthropic/claude-haiku-4-5#minimal",
+      "google/gemini-3-flash-preview",
+      "opencode/big-pickle",
+    ]);
+  });
+
+  it("prefers latest fast variants and lowest thinking effort within a provider", async () => {
+    const { rankDynamicCLIModels } = await import("./dynamic-cli-ranking.ts");
+    const models: CachedModel[] = [
+      { id: "openai-codex/gpt-5.4#high", name: "GPT-5.4 (high)" },
+      { id: "openai-codex/gpt-5.5-pro#minimal", name: "GPT-5.5 Pro (minimal)" },
+      { id: "openai-codex/gpt-5.5-mini#high", name: "GPT-5.5 Mini (high)" },
+      { id: "openai-codex/gpt-5.5-mini#minimal", name: "GPT-5.5 Mini (minimal)" },
+      { id: "openai-codex/gpt-5.5#low", name: "GPT-5.5 (low)" },
+    ];
+
+    expect(rankDynamicCLIModels(models, null).map((model) => model.id)).toEqual([
+      "openai-codex/gpt-5.5-mini#minimal",
+      "openai-codex/gpt-5.5-mini#high",
+      "openai-codex/gpt-5.5#low",
+      "openai-codex/gpt-5.5-pro#minimal",
+      "openai-codex/gpt-5.4#high",
+    ]);
+  });
+
+  it("keeps unknown ties in original CLI order", async () => {
+    const { rankDynamicCLIModels } = await import("./dynamic-cli-ranking.ts");
+    const models: CachedModel[] = [
+      { id: "local/vendor-z", name: "Vendor Z" },
+      { id: "local/vendor-a", name: "Vendor A" },
+    ];
+
+    expect(rankDynamicCLIModels(models, null).map((model) => model.id)).toEqual([
+      "local/vendor-z",
+      "local/vendor-a",
+    ]);
+  });
+
+  it("falls back to heuristic ranking when models.dev loading fails", async () => {
+    const { loadDynamicCLIModelsForSetup } = await import("./dynamic-cli-models.ts");
+
+    const models = await loadDynamicCLIModelsForSetup("test-provider", {
+      providerName: "Test Provider",
+      loadCatalog: async () => {
+        throw new Error("models.dev unavailable");
+      },
+      adapter: {
+        providerId: "test-provider",
+        mode: "cli",
+        binary: "test",
+        checkAvailable: async () => true,
+        invoke: async () => "",
+        fetchModels: async () => [
+          { id: "openai-codex/gpt-5.4-mini#high", name: "GPT-5.4 Mini (high)" },
+          { id: "openai-codex/gpt-5.5-mini#minimal", name: "GPT-5.5 Mini (minimal)" },
+        ],
+      },
+    });
+
+    expect(models.map((model) => model.id)).toEqual([
+      "openai-codex/gpt-5.5-mini#minimal",
+      "openai-codex/gpt-5.4-mini#high",
+    ]);
+  });
+});

--- a/apps/cli/src/lib/onboarding/dynamic-cli-ranking.ts
+++ b/apps/cli/src/lib/onboarding/dynamic-cli-ranking.ts
@@ -1,0 +1,202 @@
+import type { ModelCatalog, CatalogModelDefinition } from "../../providers/api/models/types.ts";
+import { normalizeModelKey } from "../../providers/api/models/provider-rules.ts";
+import { parseDynamicVariantModel } from "../../providers/cli/dynamic.ts";
+import type { CachedModel } from "../model-cache.ts";
+
+type CatalogBackedProvider = "anthropic" | "openai" | "google";
+
+const PROVIDER_PRIORITY: Array<{ rank: number; aliases: RegExp[] }> = [
+  { rank: 0, aliases: [/^openai-codex$/i] },
+  { rank: 1, aliases: [/^openai$/i] },
+  { rank: 2, aliases: [/^anthropic$/i] },
+  { rank: 3, aliases: [/^google$/i, /^gemini$/i] },
+  { rank: 4, aliases: [/^moonshot$/i, /^kimi$/i] },
+  { rank: 5, aliases: [/^zai$/i, /^glm$/i] },
+  { rank: 6, aliases: [/^deepseek$/i] },
+  { rank: 7, aliases: [/^qwen$/i, /^alibaba$/i] },
+  { rank: 8, aliases: [/^xai$/i, /^grok$/i] },
+];
+
+const FAST_TIER_PATTERNS = [
+  /(?:^|[-_])(?:mini|flash|haiku|spark|fast|nano|lite|turbo|air)(?:$|[-_])/i,
+];
+const CAPABILITY_TIER_PATTERNS = [/(?:^|[-_])(?:pro|max|opus|large)(?:$|[-_])/i];
+const EFFORT_ORDER = new Map([
+  ["none", 0],
+  ["minimal", 0],
+  ["low", 1],
+  ["medium", 2],
+  ["high", 3],
+  ["xhigh", 4],
+  ["max", 5],
+]);
+
+interface DynamicModelRankKeys {
+  model: CachedModel;
+  originalIndex: number;
+  providerRank: number;
+  version: number[];
+  updatedAt: string;
+  tierRank: number;
+  effortRank: number;
+}
+
+function splitProviderAndModel(baseModelId: string): { provider: string; modelId: string } {
+  const parts = baseModelId.split("/");
+  if (parts.length <= 1) {
+    return { provider: "", modelId: baseModelId };
+  }
+
+  return {
+    provider: parts[0] ?? "",
+    modelId: parts.slice(1).join("/") || baseModelId,
+  };
+}
+
+function normalizeProvider(provider: string, modelId: string): string {
+  const normalized = provider.toLowerCase();
+  if (normalized) return normalized;
+
+  const lowerModel = modelId.toLowerCase();
+  if (lowerModel.startsWith("gpt-") || lowerModel.startsWith("o")) return "openai";
+  if (lowerModel.startsWith("claude-")) return "anthropic";
+  if (lowerModel.startsWith("gemini-")) return "google";
+  if (lowerModel.startsWith("kimi-")) return "kimi";
+  if (lowerModel.startsWith("glm-")) return "glm";
+  if (lowerModel.startsWith("deepseek-")) return "deepseek";
+  if (lowerModel.startsWith("qwen")) return "qwen";
+  if (lowerModel.startsWith("grok-")) return "grok";
+
+  return normalized;
+}
+
+function getProviderRank(provider: string): number {
+  for (const entry of PROVIDER_PRIORITY) {
+    if (entry.aliases.some((alias) => alias.test(provider))) {
+      return entry.rank;
+    }
+  }
+
+  return 99;
+}
+
+function getCatalogProvider(provider: string): CatalogBackedProvider | null {
+  if (provider === "openai" || provider === "openai-codex") return "openai";
+  if (provider === "anthropic") return "anthropic";
+  if (provider === "google" || provider === "gemini") return "google";
+  return null;
+}
+
+function findCatalogMetadata(
+  catalog: ModelCatalog | null | undefined,
+  provider: string,
+  modelId: string,
+): CatalogModelDefinition | null {
+  if (!catalog) return null;
+
+  const catalogProviderId = getCatalogProvider(provider);
+  if (!catalogProviderId) return null;
+
+  const providerCatalog = catalog.providers[catalogProviderId];
+  const normalized = normalizeModelKey(modelId);
+  const exactId = providerCatalog.normalizedModelIndex[normalized];
+  if (exactId) return providerCatalog.models[exactId] ?? null;
+
+  let bestMatch: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const [normalizedId, actualId] of Object.entries(providerCatalog.normalizedModelIndex)) {
+    if (!normalizedId.includes(normalized) && !normalized.includes(normalizedId)) continue;
+
+    const distance = Math.abs(normalizedId.length - normalized.length);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = actualId;
+    }
+  }
+
+  return bestMatch ? (providerCatalog.models[bestMatch] ?? null) : null;
+}
+
+function extractVersion(modelId: string): number[] {
+  const id = modelId.toLowerCase();
+  const decimalMatch = id.match(/(?:^|[^0-9])(\d+(?:\.\d+)+)(?:[^0-9]|$)/);
+  if (decimalMatch?.[1]) {
+    return decimalMatch[1].split(".").map((part) => Number.parseInt(part, 10));
+  }
+
+  const numbers = id.match(/\d+/g) ?? [];
+  return numbers
+    .map((part) => Number.parseInt(part, 10))
+    .filter((value) => value > 0 && value < 1000)
+    .slice(0, 3);
+}
+
+function compareVersionDesc(a: number[], b: number[]): number {
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i += 1) {
+    const diff = (b[i] ?? 0) - (a[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+}
+
+function getTierRank(modelId: string): number {
+  if (FAST_TIER_PATTERNS.some((pattern) => pattern.test(modelId))) return 0;
+  if (CAPABILITY_TIER_PATTERNS.some((pattern) => pattern.test(modelId))) return 2;
+  return 1;
+}
+
+function getEffortRank(variant: string | undefined): number {
+  if (!variant) return 0;
+  return EFFORT_ORDER.get(variant.toLowerCase()) ?? 99;
+}
+
+function toRankKeys(
+  model: CachedModel,
+  originalIndex: number,
+  catalog: ModelCatalog | null | undefined,
+): DynamicModelRankKeys {
+  const { model: baseModelId, variant } = parseDynamicVariantModel(model.id);
+  const { provider, modelId } = splitProviderAndModel(baseModelId);
+  const normalizedProvider = normalizeProvider(provider, modelId);
+  const metadata = findCatalogMetadata(catalog, normalizedProvider, modelId);
+
+  return {
+    model,
+    originalIndex,
+    providerRank: getProviderRank(normalizedProvider),
+    version: extractVersion(modelId),
+    updatedAt: metadata?.lastUpdated || metadata?.releaseDate || "",
+    tierRank: getTierRank(modelId),
+    effortRank: getEffortRank(variant),
+  };
+}
+
+export function rankDynamicCLIModels(
+  models: CachedModel[],
+  catalog?: ModelCatalog | null,
+): CachedModel[] {
+  return models
+    .map((model, index) => toRankKeys(model, index, catalog))
+    .sort((a, b) => {
+      const providerDiff = a.providerRank - b.providerRank;
+      if (providerDiff !== 0) return providerDiff;
+
+      const versionDiff = compareVersionDesc(a.version, b.version);
+      if (versionDiff !== 0) return versionDiff;
+
+      const updatedDiff = b.updatedAt.localeCompare(a.updatedAt);
+      if (updatedDiff !== 0) return updatedDiff;
+
+      const tierDiff = a.tierRank - b.tierRank;
+      if (tierDiff !== 0) return tierDiff;
+
+      const effortDiff = a.effortRank - b.effortRank;
+      if (effortDiff !== 0) return effortDiff;
+
+      return a.originalIndex - b.originalIndex;
+    })
+    .map((ranked) => ranked.model);
+}

--- a/apps/cli/src/lib/onboarding/wizard-model-choice.test.ts
+++ b/apps/cli/src/lib/onboarding/wizard-model-choice.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+
+describe("formatModelChoiceTitle", () => {
+  it("does not mark dynamic CLI choices as recommended", async () => {
+    const { formatModelChoiceTitle } = await import("./wizard.ts");
+
+    expect(
+      formatModelChoiceTitle("GPT-5.5 Mini", "openai/gpt-5.5-mini#minimal", undefined, false),
+    ).toBe("GPT-5.5 Mini");
+  });
+
+  it("marks curated static/API recommendations when enabled", async () => {
+    const { formatModelChoiceTitle } = await import("./wizard.ts");
+
+    expect(formatModelChoiceTitle("GPT-5", "gpt-5", "gpt-5", true)).toBe("GPT-5 (recommended)");
+  });
+});

--- a/apps/cli/src/lib/onboarding/wizard.ts
+++ b/apps/cli/src/lib/onboarding/wizard.ts
@@ -234,7 +234,9 @@ async function setupCLIFlow(
       return { config: null, completed: false };
     }
 
-    const selectedModel = await selectModel(models, providerId, defaults?.model);
+    const selectedModel = await selectModel(models, providerId, defaults?.model, {
+      showRecommended: false,
+    });
     if (!selectedModel) {
       return { config: null, completed: false };
     }
@@ -433,6 +435,15 @@ async function promptForApiKey(providerName: string): Promise<string> {
   return apiKeyResult as string;
 }
 
+export function formatModelChoiceTitle(
+  modelName: string,
+  modelId: string,
+  recommendedModel: string | undefined,
+  showRecommended: boolean,
+): string {
+  return showRecommended && modelId === recommendedModel ? `${modelName} (recommended)` : modelName;
+}
+
 /**
  * Select a model with fuzzy search support for large lists.
  */
@@ -440,11 +451,13 @@ async function selectModel(
   models: CachedModel[],
   providerId: string,
   defaultModel?: string,
+  options?: { showRecommended?: boolean },
 ): Promise<string | null> {
   // Find the recommended default model
-  let recommendedModel = defaultModel;
+  const showRecommended = options?.showRecommended ?? true;
+  let recommendedModel = showRecommended ? defaultModel : undefined;
 
-  if (!recommendedModel) {
+  if (showRecommended && !recommendedModel) {
     try {
       const catalog = await getModelCatalog();
       const supportedProviderId =
@@ -464,6 +477,8 @@ async function selectModel(
     }
   }
 
+  const initialModel = defaultModel ?? recommendedModel;
+
   // For small lists (< 20 models), use @clack/prompts select
   if (models.length <= 20) {
     const modelResult = await select({
@@ -471,9 +486,9 @@ async function selectModel(
       options: models.map((m) => ({
         value: m.id,
         label: m.name,
-        hint: m.id === recommendedModel ? "recommended" : undefined,
+        hint: showRecommended && m.id === recommendedModel ? "recommended" : undefined,
       })),
-      initialValue: recommendedModel ?? models[0]?.id,
+      initialValue: initialModel ?? models[0]?.id,
     });
 
     if (isCancel(modelResult)) {
@@ -488,14 +503,14 @@ async function selectModel(
   log.info(pc.dim("Type to search models. Use arrow keys to navigate."));
 
   // Find index of recommended model for initial selection
-  const initialIndex = recommendedModel ? models.findIndex((m) => m.id === recommendedModel) : 0;
+  const initialIndex = initialModel ? models.findIndex((m) => m.id === initialModel) : 0;
 
   const result = await prompts({
     type: "autocomplete",
     name: "model",
     message: "Select model (type to search):",
-    choices: models.map((m, i) => ({
-      title: i === initialIndex ? `${m.name} (recommended)` : m.name,
+    choices: models.map((m) => ({
+      title: formatModelChoiceTitle(m.name, m.id, recommendedModel, showRecommended),
       value: m.id,
       description: m.id,
     })),

--- a/apps/cli/src/providers/api/models/catalog.ts
+++ b/apps/cli/src/providers/api/models/catalog.ts
@@ -88,7 +88,7 @@ async function loadCatalogFromOverride(): Promise<ModelCatalog | null> {
   }
 }
 
-async function resolveCatalog(forceRefresh: boolean): Promise<ModelCatalog> {
+async function resolveCatalog(forceRefresh: boolean, signal?: AbortSignal): Promise<ModelCatalog> {
   if (!forceRefresh && inMemoryCatalog) {
     return inMemoryCatalog;
   }
@@ -100,7 +100,7 @@ async function resolveCatalog(forceRefresh: boolean): Promise<ModelCatalog> {
   }
 
   try {
-    const networkCatalog = await fetchModelsDevCatalog();
+    const networkCatalog = await fetchModelsDevCatalog(signal);
     const normalized = normalizeCatalog(networkCatalog, "network");
     await saveCatalogCache(normalized);
     inMemoryCatalog = normalized;
@@ -119,11 +119,19 @@ async function resolveCatalog(forceRefresh: boolean): Promise<ModelCatalog> {
   }
 }
 
-export async function getModelCatalog(options?: { forceRefresh?: boolean }): Promise<ModelCatalog> {
+export async function getModelCatalog(options?: {
+  forceRefresh?: boolean;
+  signal?: AbortSignal;
+}): Promise<ModelCatalog> {
   const forceRefresh = options?.forceRefresh ?? false;
+  const signal = options?.signal;
 
   if (!forceRefresh && inMemoryCatalog) {
     return inMemoryCatalog;
+  }
+
+  if (signal) {
+    return await resolveCatalog(forceRefresh, signal);
   }
 
   if (!forceRefresh && inFlightCatalog) {

--- a/apps/cli/src/providers/api/models/models-dev-client.ts
+++ b/apps/cli/src/providers/api/models/models-dev-client.ts
@@ -94,12 +94,13 @@ export function createCatalogFromRaw(raw: unknown, source: ModelCatalog["source"
   };
 }
 
-export async function fetchModelsDevCatalog(): Promise<ModelCatalog> {
+export async function fetchModelsDevCatalog(signal?: AbortSignal): Promise<ModelCatalog> {
   const response = await fetch(MODELS_DEV_API_URL, {
     headers: {
       "User-Agent": "ai-git-cli",
       Accept: "application/json",
     },
+    signal,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Rank runtime-discovered Pi/OpenCode models during configure without turning models.dev into an availability dependency.

## Changes

- Add shared dynamic CLI ranking for provider priority, model version freshness, fast/small tiers, and low reasoning effort.
- Enrich runtime model rows with models.dev metadata when available, then fall back to heuristic-only ordering on catalog failure.
- Preserve original CLI order as the final tie-breaker for unknown models.
- Stop showing `(recommended)` labels for dynamic CLI provider model pickers while keeping saved defaults as the initial selection.
- Add onboarding tests for ranking policy, catalog failure fallback, and dynamic recommendation suppression.

## Test Plan

- `bun -F cli test`
- `bun -F cli typecheck`
- `bun -F cli check`

## QA

- Configure Pi or OpenCode with many runtime models; latest fast low-effort models appear before older or high-effort variants.
- Simulate models.dev/catalog failure; configure still shows the runtime model list with heuristic ordering.
- Re-open configure with an existing dynamic CLI model; the saved model remains the initial selection without a recommended badge.

## Follow up

This is a follow up pr of https://github.com/sadiksaifi/ai-git/pull/120