### PR TITLE
fix(ci): skip already published npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,13 +224,25 @@ jobs:
 
       - name: Validate all packages (dry-run)
         run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+
           for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
             echo "Validating @ai-git/${pkg}..."
+            if npm view "@ai-git/${pkg}@${VERSION}" version >/dev/null 2>&1; then
+              echo "@ai-git/${pkg}@${VERSION} already published; skipping dry-run validation."
+              continue
+            fi
             cd "packages/npm/${pkg}"
             npm publish --provenance --access public --dry-run
             cd "${{ github.workspace }}"
           done
+
           echo "Validating @ai-git/cli..."
+          if npm view "@ai-git/cli@${VERSION}" version >/dev/null 2>&1; then
+            echo "@ai-git/cli@${VERSION} already published; skipping dry-run validation."
+            exit 0
+          fi
           cd packages/npm/ai-git
           npm publish --provenance --access public --dry-run
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,15 @@ jobs:
 
       - name: Publish platform packages
         run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+
           for pkg in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-arm64 win32-x64; do
             echo "Publishing @ai-git/${pkg}..."
+            if npm view "@ai-git/${pkg}@${VERSION}" version >/dev/null 2>&1; then
+              echo "@ai-git/${pkg}@${VERSION} already published; skipping."
+              continue
+            fi
             cd "packages/npm/${pkg}"
             npm publish --provenance --access public
             cd "${{ github.workspace }}"
@@ -245,4 +252,13 @@ jobs:
 
       - name: Publish main package (@ai-git/cli)
         working-directory: packages/npm/ai-git
-        run: npm publish --provenance --access public
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+
+          if npm view "@ai-git/cli@${VERSION}" version >/dev/null 2>&1; then
+            echo "@ai-git/cli@${VERSION} already published; skipping."
+            exit 0
+          fi
+
+          npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Make npm publish recovery safe after partial release failures.

## Changes
- Derive release version from the pushed tag in publish steps.
- Skip platform package publish when `@ai-git/<platform>@<version>` already exists.
- Skip `@ai-git/cli@<version>` publish when the main package version already exists.

## Test Plan
- Not run; workflow-only guard change.

## QA
- Review release workflow publish path: fresh versions still publish; reruns after partial publish skip existing npm versions and continue.

## Closes
- None
