### PR TITLE
Improve single-page web SEO

### DIFF
--- a/apps/web/alchemy.run.ts
+++ b/apps/web/alchemy.run.ts
@@ -48,7 +48,7 @@ export const site = await Website("site", {
   ...workerDomainConfig(env),
 });
 
-// Note: www → apex redirect rule is a one-time setup via
+// Note: canonical host/scheme redirect rules are a one-time setup via
 // scripts/setup-www-redirect.ts (run locally with a CF token that has
 // Rulesets read/write). Alchemy 0.91.2's RedirectRule generates invalid
 // wirefilter ("and ssl") and doesn't expose target_url.expression for

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -2,22 +2,22 @@
   Cache-Control: public, max-age=31536000, immutable
 
 /logos/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=86400, must-revalidate
 
 /favicon.svg
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=86400, must-revalidate
 
 /logo.svg
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=86400, must-revalidate
 
 /apple-touch-icon.png
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=86400, must-revalidate
 
 /og.png
-  Cache-Control: public, max-age=604800
+  Cache-Control: public, max-age=86400, must-revalidate
 
 /twitter.png
-  Cache-Control: public, max-age=604800
+  Cache-Control: public, max-age=86400, must-revalidate
 
 /*
   Strict-Transport-Security: max-age=31536000

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,26 @@
+/_assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/logos/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/favicon.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/logo.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/apple-touch-icon.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/og.png
+  Cache-Control: public, max-age=604800
+
+/twitter.png
+  Cache-Control: public, max-age=604800
+
+/*
+  Strict-Transport-Security: max-age=31536000
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/apps/web/scripts/setup-www-redirect.ts
+++ b/apps/web/scripts/setup-www-redirect.ts
@@ -1,5 +1,6 @@
-// Creates/updates a Cloudflare Single Redirect rule:
-//   www.<DOMAIN>/* -> <DOMAIN>/* (301, path + query preserved)
+// Creates/updates Cloudflare Single Redirect rules:
+//   www.<DOMAIN>/* -> https://<DOMAIN>/* (301, path + query preserved)
+//   http://<DOMAIN>/* -> https://<DOMAIN>/* (301, path + query preserved)
 //
 // Works around Alchemy 0.91.2 RedirectRule bugs:
 //   - requestUrl generates invalid "and ssl" suffix
@@ -19,8 +20,18 @@ if (!token) throw new Error("CLOUDFLARE_API_TOKEN missing in apps/web/.env");
 if (!domain) throw new Error("DOMAIN missing in apps/web/.env");
 
 const www = `www.${domain}`;
-const apex = `https://${domain}`;
-const description = "www-to-apex";
+const httpsApex = `https://${domain}`;
+
+const redirectRules = [
+  {
+    description: "www-to-apex",
+    expression: `http.host eq "${www}"`,
+  },
+  {
+    description: "apex-http-to-https",
+    expression: `http.host eq "${domain}" and not ssl`,
+  },
+] as const;
 
 const headers = {
   Authorization: `Bearer ${token}`,
@@ -78,48 +89,52 @@ if (!ruleset) {
   console.log(`  created ruleset ${ruleset.id}`);
 }
 
-const ruleBody = {
-  action: "redirect",
-  description,
-  enabled: true,
-  expression: `http.host eq "${www}"`,
-  action_parameters: {
-    from_value: {
-      status_code: 301,
-      target_url: {
-        expression: `concat("${apex}", http.request.uri.path)`,
+for (const rule of redirectRules) {
+  const ruleBody = {
+    action: "redirect",
+    description: rule.description,
+    enabled: true,
+    expression: rule.expression,
+    action_parameters: {
+      from_value: {
+        status_code: 301,
+        target_url: {
+          expression: `concat("${httpsApex}", http.request.uri.path)`,
+        },
+        preserve_query_string: true,
       },
-      preserve_query_string: true,
     },
-  },
-};
+  };
 
-const existing = ruleset.rules.find((r) => r.description === description);
+  const existing = ruleset.rules.find((r) => r.description === rule.description);
 
-if (existing) {
-  console.log(`Updating existing rule ${existing.id}...`);
-  const patchRes = await cf(`/zones/${zoneId}/rulesets/${ruleset.id}/rules/${existing.id}`, {
-    method: "PATCH",
-    body: JSON.stringify(ruleBody),
-  });
-  const patchJson = (await patchRes.json()) as { success: boolean; errors?: unknown };
-  if (!patchJson.success) {
-    console.error(JSON.stringify(patchJson, null, 2));
-    throw new Error("Patch failed");
+  if (existing) {
+    console.log(`Updating existing rule ${existing.id} (${rule.description})...`);
+    const patchRes = await cf(`/zones/${zoneId}/rulesets/${ruleset.id}/rules/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify(ruleBody),
+    });
+    const patchJson = (await patchRes.json()) as { success: boolean; errors?: unknown };
+    if (!patchJson.success) {
+      console.error(JSON.stringify(patchJson, null, 2));
+      throw new Error(`Patch failed: ${rule.description}`);
+    }
+    console.log(`  ✓ updated`);
+  } else {
+    console.log(`Creating new rule (${rule.description})...`);
+    const postRes = await cf(`/zones/${zoneId}/rulesets/${ruleset.id}/rules`, {
+      method: "POST",
+      body: JSON.stringify(ruleBody),
+    });
+    const postJson = (await postRes.json()) as { success: boolean; errors?: unknown };
+    if (!postJson.success) {
+      console.error(JSON.stringify(postJson, null, 2));
+      throw new Error(`Create failed: ${rule.description}`);
+    }
+    console.log(`  ✓ created`);
   }
-  console.log(`  ✓ updated`);
-} else {
-  console.log(`Creating new rule...`);
-  const postRes = await cf(`/zones/${zoneId}/rulesets/${ruleset.id}/rules`, {
-    method: "POST",
-    body: JSON.stringify(ruleBody),
-  });
-  const postJson = (await postRes.json()) as { success: boolean; errors?: unknown };
-  if (!postJson.success) {
-    console.error(JSON.stringify(postJson, null, 2));
-    throw new Error("Create failed");
-  }
-  console.log(`  ✓ created`);
 }
 
-console.log(`\nDone. Test: curl -sI https://${www}/some-path`);
+console.log(`\nDone. Test:`);
+console.log(`  curl -sI https://${www}/some-path`);
+console.log(`  curl -sI http://${domain}/some-path`);

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -37,11 +37,11 @@ const heroBody = renderTerminalLines(heroLines)
     <div class="hero-grid">
       <div class="hero-copy">
         <h1>
-          Stop writing <span class="faded">commit</span> <span class="accent">messages.</span>
+          ai-git commit <span class="faded">message</span> <span class="accent">generator.</span>
         </h1>
         <p class="hero-sub">
-          ai-git reads your diff and writes a conventional commit. Scope, subject, body, the lot. Pick
-          a provider. Review. Ship.
+          ai-git reads your diff and writes Conventional Commits-compliant messages. Scope, subject,
+          body, the lot. Pick a provider. Review. Ship.
         </p>
 
         <div class="hero-ctas">

--- a/apps/web/src/components/SeoContent.astro
+++ b/apps/web/src/components/SeoContent.astro
@@ -1,0 +1,91 @@
+<section class="section seo-content" aria-labelledby="seo-content-title">
+  <div class="container">
+    <header class="section-head">
+      <span class="eyebrow">Why ai-git</span>
+      <h2 id="seo-content-title">Generate commit messages from your git diff.</h2>
+      <p>
+        ai-git is an AI git commit message generator built for developers who want clean,
+        reviewable commit history without writing every subject and body by hand.
+      </p>
+    </header>
+
+    <div class="seo-grid">
+      <article>
+        <h3>Conventional Commits by default</h3>
+        <p>
+          The CLI reads staged or unstaged changes, infers the intent of the diff, and formats the
+          result as a Conventional Commits-compliant message. It can generate scopes, subjects,
+          multiline bodies, and footers while still letting you edit or retry before committing.
+        </p>
+      </article>
+
+      <article>
+        <h3>Bring your own AI provider</h3>
+        <p>
+          Use Claude Code, Gemini CLI, Codex, OpenCode, Pi, OpenAI, Anthropic, Google AI Studio,
+          OpenRouter, or Cerebras. Your code diff is sent only to the provider you choose; ai-git
+          does not proxy requests or silently fall back to another service.
+        </p>
+      </article>
+
+      <article>
+        <h3>Team-ready configuration</h3>
+        <p>
+          Commit a project-level <code>.ai-git.json</code> to standardize scopes, ticket references,
+          examples, and commit style across a repo. Developers can still override provider, model,
+          staging, commit, and push behavior per run with CLI flags.
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
+<style>
+  .section {
+    padding-block: var(--section-y);
+    border-top: 1px solid var(--color-border-subtle);
+  }
+  .seo-grid {
+    margin-top: var(--space-10);
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    background: var(--color-bg-elev);
+  }
+  article {
+    padding: var(--space-6);
+    border-right: 1px solid var(--color-border-subtle);
+  }
+  article:last-child {
+    border-right: 0;
+  }
+  h3 {
+    font-size: var(--text-base);
+    font-weight: 500;
+    color: var(--color-fg);
+  }
+  article p {
+    margin-top: var(--space-3);
+    color: var(--color-fg-dim);
+    font-size: var(--text-sm);
+    line-height: 1.65;
+  }
+  code {
+    color: var(--color-fg-dim);
+  }
+  @media (max-width: 860px) {
+    .seo-grid {
+      grid-template-columns: 1fr;
+    }
+    article {
+      border-right: 0;
+      border-bottom: 1px solid var(--color-border-subtle);
+    }
+    article:last-child {
+      border-bottom: 0;
+    }
+  }
+</style>

--- a/apps/web/src/layouts/Base.astro
+++ b/apps/web/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import { Font } from "astro:assets"
-import { seo } from "@ai-git/content/web"
+import { faq, seo } from "@ai-git/content/web"
 import "../styles/global.css"
 
 interface Props {
@@ -13,6 +13,54 @@ const pathname = Astro.url.pathname.replace(/\/index\.html$/, "/").replace(/\/$/
 const canonical = new URL(pathname, seo.site.url).toString()
 const ogImage = new URL(seo.openGraph.images[0].url, seo.site.url).toString()
 const twitterImage = new URL(seo.twitter.image.url, seo.site.url).toString()
+const logo = new URL(seo.icons.faviconSvg, seo.site.url).toString()
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, "")
+const structuredData = [
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: seo.site.name,
+    url: seo.site.url,
+    description,
+    inLanguage: "en",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: seo.site.name,
+    alternateName: "AI Git Commit Message Generator",
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "macOS, Linux, Windows",
+    url: seo.site.url,
+    downloadUrl: "https://www.npmjs.com/package/@ai-git/cli",
+    codeRepository: "https://github.com/sadiksaifi/ai-git",
+    image: ogImage,
+    logo,
+    description,
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    author: {
+      "@type": "Person",
+      name: "Sadik Saifi",
+      url: "https://sadiksaifi.dev",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: stripHtml(item.answer),
+      },
+    })),
+  },
+]
 ---
 
 <!doctype html>
@@ -34,6 +82,7 @@ const twitterImage = new URL(seo.twitter.image.url, seo.site.url).toString()
 
     <meta property="og:type" content={seo.openGraph.type} />
     <meta property="og:site_name" content={seo.openGraph.siteName} />
+    <meta property="og:locale" content={seo.site.locale} />
     <meta property="og:url" content={canonical} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
@@ -49,6 +98,8 @@ const twitterImage = new URL(seo.twitter.image.url, seo.site.url).toString()
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={twitterImage} />
     <meta name="twitter:image:alt" content={seo.twitter.image.alt} />
+
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(structuredData)}></script>
 
     <slot name="head" />
   </head>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from "../components/Hero.astro"
 import HowItWorks from "../components/HowItWorks.astro"
 import ProviderGrid from "../components/ProviderGrid.astro"
 import ConfigSection from "../components/ConfigSection.astro"
+import SeoContent from "../components/SeoContent.astro"
 import FAQ from "../components/FAQ.astro"
 import Footer from "../components/Footer.astro"
 ---
@@ -16,6 +17,7 @@ import Footer from "../components/Footer.astro"
     <HowItWorks />
     <ProviderGrid />
     <ConfigSection />
+    <SeoContent />
     <FAQ />
   </main>
   <Footer />

--- a/packages/content/src/web.ts
+++ b/packages/content/src/web.ts
@@ -20,9 +20,9 @@ export const seo = {
     themeColor: "#0a0a0a",
   },
   home: {
-    title: "ai-git — stop writing commit messages",
+    title: "AI Git Commit Message Generator CLI | ai-git",
     description:
-      "A CLI that reads your diff and writes a Conventional Commits-compliant message. Bring your own AI — Claude Code, Gemini CLI, Codex, OpenCode, Pi, OpenRouter, OpenAI, Google AI Studio, Anthropic, Cerebras.",
+      "ai-git reads your git diff and writes Conventional Commits-compliant messages with Claude, OpenAI, Gemini, OpenRouter, and local CLI providers.",
   } as PageSEO,
   docs: {
     title: "Docs — ai-git",


### PR DESCRIPTION
## Summary

- Improve the single-page web SEO surface without adding extra routes.
- Add structured search metadata, crawlable keyword copy, asset/security headers, and canonical redirect automation.

## Changes

- Retarget homepage title, description, and H1 around `ai-git commit message generator` / Conventional Commits intent.
- Add crawlable single-page SEO copy for diff-based commit generation, supported providers, and team configuration.
- Add `WebSite`, `SoftwareApplication`, and `FAQPage` JSON-LD from existing site/FAQ content.
- Add Cloudflare `_headers` for immutable static asset caching, HSTS, and basic security headers.
- Extend the Cloudflare redirect setup script to enforce both `www` → apex and HTTP apex → HTTPS apex redirects.

## Test Plan

- `bun run --filter web check`
- `bun run --filter web typecheck`
- `bun run --filter web build`
- Verified live `http://ai-git.xyz` returns `301` to `https://ai-git.xyz/`.

## QA

- Homepage review: hero keeps the single-page product pitch while exposing the target commit-message-generator query.
- Page source review: title, meta description, canonical URL, Open Graph locale, and JSON-LD are present.
- Crawlability review: added SEO copy is server-rendered HTML, not client-only content.
- Routing review: HTTP apex and `www` requests resolve to the HTTPS apex canonical URL.

## Closes

- None
