### PR TITLE
ci: configure Tagsmith release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch tags and remote branches
+        run: git fetch --force --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+
+      - name: Validate release tag
+        id: tagsmith
+        run: bunx tagsmith@latest validate --tag "$GITHUB_REF_NAME" --github-output
 
       - name: Install dependencies
         run: bun install
@@ -80,7 +87,7 @@ jobs:
 
       - name: Generate checksums
         working-directory: apps/cli/dist
-        run: shasum -a 256 *.tar.gz *.zip > checksums.txt
+        run: shasum -a 256 ./*.tar.gz ./*.zip > checksums.txt
 
       - name: Generate Changelog
         uses: orhun/git-cliff-action@v4
@@ -92,7 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.changelog.outputs.content }}
           generate_release_notes: false
@@ -116,7 +123,7 @@ jobs:
 
       - name: Update Homebrew Formula
         run: |
-          VERSION=${{ github.ref_name }}
+          VERSION="${{ github.ref_name }}"
 
           URL_ARM64="https://github.com/${{ github.repository }}/releases/download/${VERSION}/ai-git-darwin-arm64.tar.gz"
           SHA256_ARM64=$(shasum -a 256 apps/cli/dist/ai-git-darwin-arm64.tar.gz | awk '{print $1}')
@@ -132,12 +139,12 @@ jobs:
           sed -i "s|version \".*\"|version \"${VERSION#v}\"|" ai-git.rb
 
           # Update ARM64 (range: if arm? ... else)
-          sed -i '/if Hardware::CPU.arm?/,/else/s|url ".*"|url "'$URL_ARM64'"|' ai-git.rb
-          sed -i '/if Hardware::CPU.arm?/,/else/s|sha256 ".*"|sha256 "'$SHA256_ARM64'"|' ai-git.rb
+          sed -i "/if Hardware::CPU.arm?/,/else/s|url \".*\"|url \"${URL_ARM64}\"|" ai-git.rb
+          sed -i "/if Hardware::CPU.arm?/,/else/s|sha256 \".*\"|sha256 \"${SHA256_ARM64}\"|" ai-git.rb
 
           # Update X64 (range: else ... end)
-          sed -i '/else/,/end/s|url ".*"|url "'$URL_X64'"|' ai-git.rb
-          sed -i '/else/,/end/s|sha256 ".*"|sha256 "'$SHA256_X64'"|' ai-git.rb
+          sed -i "/else/,/end/s|url \".*\"|url \"${URL_X64}\"|" ai-git.rb
+          sed -i "/else/,/end/s|sha256 \".*\"|sha256 \"${SHA256_X64}\"|" ai-git.rb
 
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"

--- a/.tagsmith.jsonc
+++ b/.tagsmith.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://tagsmith.sadiksaifi.dev/schema/v1.json",
+  "configVersion": 1,
+
+  "git": {
+    "remote": "origin",
+    "baseBranch": "main",
+  },
+
+  "defaults": {
+    "tagPattern": "v{version}",
+    "tagMessage": "Release {version}",
+    "initialVersion": "2.10.0",
+  },
+
+  "targets": {
+    "ai-git": {
+      "path": ".",
+      "channels": [{ "name": "stable", "strategy": "stable" }],
+    },
+  },
+}

--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ bun run build
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
+## Releases
+
+Releases are managed by [Tagsmith](https://tagsmith.sadiksaifi.dev/). Use `bunx tagsmith@latest` to create and validate release tags.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
<!-- Thank you for contributing to ai-git! -->

### Description

Configure Tagsmith as the release tag manager for this repository and gate the existing release workflow on Tagsmith tag validation before publish/release side effects run.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other

### Changes

- Add a Tagsmith config for the existing `v{version}` release tag namespace, with `v2.10.0` as the legacy adoption boundary for historical lightweight tags.
- Validate pushed release tags in the GitHub release workflow before dependencies are installed, artifacts are built, GitHub Releases are created, Homebrew is updated, or npm packages are published.
- Fetch tags and remote branches in the release workflow so Tagsmith can prove tag reachability from `origin/main`.
- Clean up release workflow lint findings by updating the GitHub Release action and quoting shell/glob usage safely.
- Document the Tagsmith release workflow in the README.

### Testing

- [x] Ran `bunx tagsmith@latest targets --json` to validate `.tagsmith.jsonc`.
- [x] Ran `actionlint .github/workflows/release.yml` to validate the release workflow.
- [ ] Tested on macOS version: N/A
- [ ] Tested with different input types: N/A
- [ ] Tested in pipe chains: N/A

## QA

- Push a new annotated release tag above `v2.10.0` that matches `v{version}`. The release workflow should fetch tags and remote branches, validate the tag with Tagsmith, and only then continue to build/release/publish steps.
- Push or inspect an old historical tag at or below `v2.10.0`. Tagsmith should treat it as outside the managed release history rather than requiring legacy lightweight tags to be rewritten.

### Screenshots

N/A

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
