### PR TITLE
fix(cli): disable ai spinner for non-tty output

### DIFF
--- a/apps/cli/src/machines/actors/ai.actors.test.ts
+++ b/apps/cli/src/machines/actors/ai.actors.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 import { createActor, waitFor } from "xstate";
 import { createInvokeAIActor } from "./ai.actors.ts";
 
@@ -40,5 +40,32 @@ describe("createInvokeAIActor", () => {
     } catch (e) {
       expect((e as Error).message).toBe("API rate limit exceeded");
     }
+  });
+
+  test("does not create an animated spinner for non-interactive output", async () => {
+    const spinnerFactory = mock(() => ({
+      start: mock(() => {}),
+      message: mock(() => {}),
+      stop: mock(() => {}),
+    }));
+    const actor = createInvokeAIActor(async () => "feat: add login", {
+      shouldUseInteractiveSpinner: () => false,
+      spinnerFactory,
+    });
+    const ref = createActor(actor, {
+      input: {
+        model: "test",
+        system: "system prompt",
+        prompt: "user prompt",
+        modelName: "Test Model",
+        slowThresholdMs: 0,
+      },
+    });
+
+    ref.start();
+    const snap = await waitFor(ref, (s) => s.status === "done");
+
+    expect(snap.output).toBe("feat: add login");
+    expect(spinnerFactory).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/machines/actors/ai.actors.ts
+++ b/apps/cli/src/machines/actors/ai.actors.ts
@@ -15,6 +15,28 @@ type InvokeAIInput = {
   adapter?: ProviderAdapter;
 };
 
+type SpinnerController = Pick<ReturnType<typeof spinner>, "start" | "message" | "stop">;
+
+type InvokeAIActorOptions = {
+  shouldUseInteractiveSpinner?: () => boolean;
+  spinnerFactory?: () => SpinnerController;
+};
+
+const noopSpinner: SpinnerController = {
+  start: () => {},
+  message: () => {},
+  stop: () => {},
+};
+
+export function shouldUseInteractiveSpinner(): boolean {
+  return (
+    Boolean(process.stdout.isTTY) &&
+    Boolean(process.stderr.isTTY) &&
+    !process.env.CI &&
+    process.env.TERM !== "dumb"
+  );
+}
+
 // ── Factory ──────────────────────────────────────────────────────────
 
 /**
@@ -26,6 +48,7 @@ type InvokeAIInput = {
  */
 export function createInvokeAIActor(
   resolver?: (input: { model: string; system: string; prompt: string }) => Promise<string>,
+  options: InvokeAIActorOptions = {},
 ) {
   return fromPromise(async ({ input }: { input: InvokeAIInput }) => {
     const invoke =
@@ -35,7 +58,10 @@ export function createInvokeAIActor(
         return input.adapter.invoke(opts);
       });
 
-    const s = spinner();
+    const useInteractiveSpinner =
+      options.shouldUseInteractiveSpinner ?? shouldUseInteractiveSpinner;
+    const createSpinner = options.spinnerFactory ?? spinner;
+    const s = useInteractiveSpinner() ? createSpinner() : noopSpinner;
     s.start(`Analyzing changes with ${input.modelName}...`);
 
     const cancelSlowWarning = createSlowWarningTimer(input.slowThresholdMs, () => {


### PR DESCRIPTION
<!-- Thank you for contributing to ai-git! -->

### Description

Prevents the AI generation spinner from writing repeated status messages when ai-git output is captured or piped through a non-interactive stream.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other

### Changes

- Gate the animated `@clack/prompts` spinner behind an interactive TTY check for both stdout and stderr.
- Use a no-op spinner in non-TTY, CI, or dumb-terminal environments so captured output does not receive repaint escape sequences.
- Add actor-level coverage for non-interactive output to prove the spinner is not constructed.

### Testing

- [x] Tested on macOS version: 26.4.1
- [x] Tested with different input types
- [x] Tested in pipe chains

Automated verification performed:

- `bun test ./apps/cli/src/machines/actors/ai.actors.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run test`

### Screenshots

N/A

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA

- From the old `main` worktree, run the AI actor repro with output piped through `cat -v`; repeated `Still generating...` spinner frames should appear.
- From this branch, run the same repro with `2>&1 | cat -v`; only `DONE` should print, confirming captured output no longer receives animated spinner frames.
