### PR TITLE
fix(cli): prevent wrapped spinner output

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,7 +30,7 @@
     "@ai-sdk/cerebras": "^2.0.33",
     "@ai-sdk/google": "^3.0.1",
     "@ai-sdk/openai": "^3.0.1",
-    "@clack/prompts": "^0.11.0",
+    "@clack/prompts": "^1.2.0",
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "ai": "^6.0.5",
     "cac": "^6.7.14",

--- a/apps/cli/src/lib/onboarding/wizard.ts
+++ b/apps/cli/src/lib/onboarding/wizard.ts
@@ -210,7 +210,7 @@ async function setupCLIFlow(
       models = await loadDynamicCLIModelsForSetup(providerId, { providerName: providerDef.name });
       s.stop(pc.green(`Found ${models.length} models`));
     } catch (error) {
-      s.stop(pc.red("Error fetching models"));
+      s.error("Error fetching models");
       log.error("");
       log.error(pc.red(error instanceof Error ? error.message : "Model listing failed."));
       log.error("");
@@ -330,7 +330,7 @@ async function setupAPIFlow(ctx: FlowContext, providerId: string): Promise<Wizar
   try {
     const adapter = getAPIAdapter(providerId);
     if (!adapter) {
-      s.stop(pc.red("Error: Provider adapter not found"));
+      s.error("Error: Provider adapter not found");
       return { config: null, completed: false };
     }
 
@@ -338,7 +338,7 @@ async function setupAPIFlow(ctx: FlowContext, providerId: string): Promise<Wizar
     const fetchedModels = await adapter.fetchModels(apiKey);
 
     if (fetchedModels.length === 0) {
-      s.stop(pc.red("Error: No models available"));
+      s.error("Error: No models available");
       log.error(pc.red("The API returned no models. Please check your API key."));
       return { config: null, completed: false };
     }
@@ -358,7 +358,7 @@ async function setupAPIFlow(ctx: FlowContext, providerId: string): Promise<Wizar
 
     s.stop(pc.green(`Found ${models.length} models`));
   } catch (error) {
-    s.stop(pc.red("Error validating API key"));
+    s.error("Error validating API key");
     log.error("");
     log.error(pc.red(`API Error: ${error instanceof Error ? error.message : "Unknown error"}`));
     log.error("");

--- a/apps/cli/src/machines/actors/ai.actors.test.ts
+++ b/apps/cli/src/machines/actors/ai.actors.test.ts
@@ -47,6 +47,7 @@ describe("createInvokeAIActor", () => {
       start: mock(() => {}),
       message: mock(() => {}),
       stop: mock(() => {}),
+      error: mock(() => {}),
     }));
     const actor = createInvokeAIActor(async () => "feat: add login", {
       shouldUseInteractiveSpinner: () => false,

--- a/apps/cli/src/machines/actors/ai.actors.ts
+++ b/apps/cli/src/machines/actors/ai.actors.ts
@@ -15,7 +15,7 @@ type InvokeAIInput = {
   adapter?: ProviderAdapter;
 };
 
-type SpinnerController = Pick<ReturnType<typeof spinner>, "start" | "message" | "stop">;
+type SpinnerController = Pick<ReturnType<typeof spinner>, "start" | "message" | "stop" | "error">;
 
 type InvokeAIActorOptions = {
   shouldUseInteractiveSpinner?: () => boolean;
@@ -26,6 +26,7 @@ const noopSpinner: SpinnerController = {
   start: () => {},
   message: () => {},
   stop: () => {},
+  error: () => {},
 };
 
 export function shouldUseInteractiveSpinner(): boolean {
@@ -83,7 +84,7 @@ export function createInvokeAIActor(
       return rawMsg;
     } catch (e) {
       cancelSlowWarning();
-      s.stop("Generation failed");
+      s.error("Generation failed");
       throw e;
     }
   });

--- a/apps/cli/src/machines/actors/ai.actors.ts
+++ b/apps/cli/src/machines/actors/ai.actors.ts
@@ -63,12 +63,12 @@ export function createInvokeAIActor(
       options.shouldUseInteractiveSpinner ?? shouldUseInteractiveSpinner;
     const createSpinner = options.spinnerFactory ?? spinner;
     const s = useInteractiveSpinner() ? createSpinner() : noopSpinner;
-    s.start(`Analyzing changes with ${input.modelName}...`);
+    s.start(`Generating with ${input.modelName}`);
 
     const cancelSlowWarning = createSlowWarningTimer(input.slowThresholdMs, () => {
       s.message(
         pc.yellow(
-          `Still generating with ${input.modelName}... Speed depends on your selected provider and model.`,
+          `Still generating with ${input.modelName}, speed varies by provider/model`,
         ),
       );
     });

--- a/apps/cli/src/machines/actors/clack.actors.ts
+++ b/apps/cli/src/machines/actors/clack.actors.ts
@@ -60,7 +60,10 @@ export function createConfirmActor(
 
 export function createTextActor(
   resolver: (input: TextInput) => Promise<string | symbol> = (input) =>
-    text(input) as Promise<string | symbol>,
+    text({
+      ...input,
+      validate: input.validate ? (value) => input.validate?.(value ?? "") : undefined,
+    }) as Promise<string | symbol>,
 ) {
   return fromPromise(async ({ input }: { input: TextInput }) => {
     const result = await resolver(input);

--- a/apps/cli/src/machines/cli.wired.ts
+++ b/apps/cli/src/machines/cli.wired.ts
@@ -344,7 +344,7 @@ export const wiredCliMachine = cliMachine.provide({
             await push();
             s.stop("Pushed successfully");
           } catch (error) {
-            s.stop("Push failed", 1);
+            s.error("Push failed");
             throw error;
           }
         }),
@@ -355,7 +355,7 @@ export const wiredCliMachine = cliMachine.provide({
             await addRemoteAndPush(input.url);
             s.stop("Remote added and pushed successfully");
           } catch (error) {
-            s.stop("Failed to push to new remote", 1);
+            s.error("Failed to push to new remote");
             throw error;
           }
         }),
@@ -366,7 +366,7 @@ export const wiredCliMachine = cliMachine.provide({
             await fetchRemote();
             s.stop("Checked remote");
           } catch (error) {
-            s.stop("Could not reach remote", 1);
+            s.error("Could not reach remote");
             throw error;
           }
         }),
@@ -380,7 +380,7 @@ export const wiredCliMachine = cliMachine.provide({
             await pullRebase();
             s.stop("Rebased successfully");
           } catch (error) {
-            s.stop("Rebase failed", 1);
+            s.error("Rebase failed");
             throw error;
           }
         }),

--- a/apps/cli/src/machines/upgrade.wired.ts
+++ b/apps/cli/src/machines/upgrade.wired.ts
@@ -37,7 +37,7 @@ export const wiredUpgradeMachine = upgradeMachine.provide({
         }
         return result;
       } catch (error) {
-        s.stop(extractErrorMessage(error), 1);
+        s.error(extractErrorMessage(error));
         throw error;
       }
     }),
@@ -55,7 +55,7 @@ export const wiredUpgradeMachine = upgradeMachine.provide({
         s.stop("Platform detected");
         return platform;
       } catch (error) {
-        s.stop(extractErrorMessage(error), 1);
+        s.error(extractErrorMessage(error));
         throw error;
       }
     }),
@@ -69,7 +69,7 @@ export const wiredUpgradeMachine = upgradeMachine.provide({
           s.stop("Downloaded");
           return result;
         } catch (error) {
-          s.stop(extractErrorMessage(error), 1);
+          s.error(extractErrorMessage(error));
           throw error;
         }
       },
@@ -92,7 +92,7 @@ export const wiredUpgradeMachine = upgradeMachine.provide({
           if (!valid) throw new Error("Checksum verification failed. Aborting upgrade.");
           s.stop("Checksum verified");
         } catch (error) {
-          s.stop(extractErrorMessage(error), 1);
+          s.error(extractErrorMessage(error));
           throw error;
         }
       },
@@ -107,7 +107,7 @@ export const wiredUpgradeMachine = upgradeMachine.provide({
           s.stop("Extracted");
           return result;
         } catch (error) {
-          s.stop(extractErrorMessage(error), 1);
+          s.error(extractErrorMessage(error));
           throw error;
         }
       },
@@ -125,7 +125,7 @@ export const wiredUpgradeMachine = upgradeMachine.provide({
           installBinary(input.extractedBinPath);
           s.stop(`Upgraded ai-git: ${input.version} -> ${input.latestVersion}`);
         } catch (error) {
-          s.stop(extractErrorMessage(error), 1);
+          s.error(extractErrorMessage(error));
           throw error;
         }
       },

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "@ai-sdk/cerebras": "^2.0.33",
         "@ai-sdk/google": "^3.0.1",
         "@ai-sdk/openai": "^3.0.1",
-        "@clack/prompts": "^0.11.0",
+        "@clack/prompts": "^1.2.0",
         "@openrouter/ai-sdk-provider": "^2.2.3",
         "ai": "^6.0.5",
         "cac": "^6.7.14",
@@ -208,9 +208,9 @@
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
-    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+    "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
-    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+    "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
 
@@ -1448,6 +1448,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@ai-git/meta/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@astrojs/check/kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
@@ -1474,9 +1476,9 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "astro/@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
-
     "astro/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "cli/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
@@ -1518,6 +1520,8 @@
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "@ai-git/meta/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
@@ -1531,8 +1535,6 @@
     "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
-
-    "astro/@clack/prompts/@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
     "astro/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -1585,6 +1587,8 @@
     "astro/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
     "astro/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "cli/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 


### PR DESCRIPTION
### Description

Update Clack Prompts to its current major version so long spinner messages are wrapped and redrawn correctly instead of accumulating across terminal rows.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other

### Changes

- Upgrade `@clack/prompts` from 0.11.0 to 1.2.0.
- Migrate failed spinners to the v1 `error()` API.
- Normalize optional text prompt values before running existing validators.
- Update the AI spinner controller and test doubles for the v1 API.
- Keep the initial and delayed generation messages concise and continuous while clarifying that speed varies by provider and model.

### Testing

- [x] `bun run test`
- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun run build:cli`

## QA

- In an 80-column terminal, run a generation with GPT-5.6 Sol (high) that lasts longer than five seconds. The spinner should transition from “Generating with…” to “Still generating with…” on one line without duplicated output accumulating.
- Trigger a failed push or provider request and confirm the spinner ends with the error indicator and message.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
