### PR TITLE
fix(cli): preserve terminal scrollback on launch

### DIFF
--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -103,7 +103,7 @@ export function queueMigrationNotice(notice: MigrationNotice): void {
 
 /**
  * Show any pending migration notice and clear it.
- * Call this after the welcome screen renders so `console.clear()` doesn't wipe it.
+ * Call this after the welcome screen renders so the fresh viewport doesn't hide it.
  */
 export function flushMigrationNotice(): void {
   if (pendingMigrationNotice) {

--- a/apps/cli/src/lib/ui/welcome.test.ts
+++ b/apps/cli/src/lib/ui/welcome.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { freshViewportSequence } from "./welcome.ts";
+
+describe("freshViewportSequence", () => {
+  test("scrolls the visible screen into history and returns to the top", () => {
+    const sequence = freshViewportSequence(3);
+
+    expect(sequence).toBe("\x1b[3;1H\n\n\n\x1b[H");
+    expect(sequence).not.toContain("\x1b[2J");
+    expect(sequence).not.toContain("\x1b[3J");
+  });
+
+  test("returns no output for invalid terminal heights", () => {
+    expect(freshViewportSequence(0)).toBe("");
+    expect(freshViewportSequence(-1)).toBe("");
+    expect(freshViewportSequence(1.5)).toBe("");
+  });
+});

--- a/apps/cli/src/lib/ui/welcome.ts
+++ b/apps/cli/src/lib/ui/welcome.ts
@@ -14,6 +14,22 @@ export interface WelcomeResult {
 }
 
 /**
+ * Build a blank viewport while retaining the current screen in scrollback.
+ */
+export function freshViewportSequence(rows: number): string {
+  if (!Number.isInteger(rows) || rows <= 0) return "";
+
+  return `\x1b[${rows};1H${"\n".repeat(rows)}\x1b[H`;
+}
+
+function startOnFreshViewport(): void {
+  if (!process.stdout.isTTY) return;
+
+  const sequence = freshViewportSequence(process.stdout.rows);
+  if (sequence) process.stdout.write(sequence);
+}
+
+/**
  * Strip ANSI escape codes from a string.
  */
 function stripAnsi(str: string): string {
@@ -90,7 +106,7 @@ export async function showWelcomeScreen(
   version: string,
   options?: WelcomeOptions,
 ): Promise<WelcomeResult> {
-  console.clear();
+  startOnFreshViewport();
 
   // Layout dimensions
   const leftWidth = 30;


### PR DESCRIPTION
<!-- Thank you for contributing to ai-git! -->

### Description

Keep terminal history available when AI Git launches while still rendering the welcome screen at the top of a fresh viewport.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other

### Changes

- Replace `console.clear()` with a primary-screen sequence that scrolls the visible viewport into history and returns the cursor to the top.
- Skip terminal control output when stdout is not a TTY.
- Add focused coverage that prevents screen and scrollback erase sequences from being reintroduced.

### Testing

- [x] Tested on macOS in an interactive terminal
- [ ] Tested with different input types
- [x] Tested in pipe chains through CLI integration tests
- [x] `bun test src/index.test.ts src/lib/ui/welcome.test.ts`
- [x] `bun run typecheck`
- [x] `bun run check`

### Screenshots

Not applicable.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## QA

- Launch `ai-git` from a terminal containing prior output. The welcome screen should begin at the top of a blank viewport. Scroll upward to confirm the prior terminal output remains available, then exit AI Git and confirm the CLI output also remains in the terminal history.
